### PR TITLE
Add turing machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/
 .*.aux
 *.a
 *.cma

--- a/_CoqProject
+++ b/_CoqProject
@@ -3,5 +3,6 @@
 src/Algebraic_Structures.v
 src/Domain.v
 src/NEList.v
+src/Endo.v
 src/LFP.v
 src/TM.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,7 +1,7 @@
 -Q src klenee_complexity
 
 src/Algebraic_Structures.v
-src/Conf.v
 src/Domain.v
 src/NEList.v
 src/LFP.v
+src/TM.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,9 +1,9 @@
 -Q src klenee_complexity
 
 src/Algebraic_Structures.v
-src/Conf.v
-src/Domain.v
 src/NEList.v
-src/LFP.v
+src/TM.v
 src/Image_Facts.v
+src/Domain.v
+src/LFP.v
 src/Endo.v

--- a/src/Conf.v
+++ b/src/Conf.v
@@ -1,7 +1,0 @@
-From klenee_complexity Require Import NEList.
-
-Record Conf := {
-    (* TODO *)
-}.
-
-Definition Trace := NEList Conf.

--- a/src/Domain.v
+++ b/src/Domain.v
@@ -1,430 +1,435 @@
-From klenee_complexity Require Import Algebraic_Structures Conf.
-From Coq Require Import Strings.String Logic.Classical Sets.Powerset Logic.FunctionalExtensionality Sets.Constructive_sets.
+From klenee_complexity Require Import Algebraic_Structures TM.
+From Coq Require Import Logic.Classical Sets.Powerset Logic.FunctionalExtensionality Sets.Constructive_sets.
 
-Definition Domain := string -> Ensemble Trace.
+Section Domain.
+  Context `{params : TMParams}.
 
-Instance Domain_MonoidOps : Monoid_Ops Domain := {
-    one := fun _ => Full_set Trace;
-    dot a b := fun i => Intersection Trace (a i) (b i)
-}.
+  Definition Domain := list Σ -> Ensemble Trace.
 
-Lemma dot_assoc_domain : forall (x y z : Domain),
-    x * (y * z) = (x * y) * z.
-Proof.
-  intros x y z.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  unfold Same_set.
-  split; unfold Included; intros t H.
-  - inversion H as [t' H1 H2].
-    inversion H2 as [t'' H3 H4].
-    constructor.
-    + constructor; assumption.
-    + assumption.
-  - inversion H as [t' H1 H2].
-    inversion H1 as [t'' H3 H4].
-    constructor.
-    + assumption.
-    + constructor; assumption.
-Qed.
+  Global Instance Domain_MonoidOps : Monoid_Ops Domain := {
+      one := fun _ => Full_set Trace;
+      dot a b := fun i => Intersection Trace (a i) (b i)
+  }.
 
-Lemma dot_neutral_left_domain : forall (x : Domain),
-    1 * x = x.
-Proof.
-  intros x.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  unfold Same_set.
-  split; unfold Included; intros t H.
-  - inversion H as [t' H1 H2].
-    assumption.
-  - constructor.
-    + constructor.
-    + assumption.
-Qed.
+  Lemma dot_assoc_domain : forall (x y z : Domain),
+      x * (y * z) = (x * y) * z.
+  Proof.
+    intros x y z.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    unfold Same_set.
+    split; unfold Included; intros t H.
+    - inversion H as [t' H1 H2].
+      inversion H2 as [t'' H3 H4].
+      constructor.
+      + constructor; assumption.
+      + assumption.
+    - inversion H as [t' H1 H2].
+      inversion H1 as [t'' H3 H4].
+      constructor.
+      + assumption.
+      + constructor; assumption.
+  Qed.
 
-Lemma dot_neutral_right_domain : forall (x : Domain),
-    x * 1 = x.
-Proof.
-  intros x.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  unfold Same_set.
-  split; unfold Included; intros t H.
-  - inversion H as [t' H1 H2].
-    assumption.
-  - constructor.
-    + assumption.
-    + constructor.
-Qed.
+  Lemma dot_neutral_left_domain : forall (x : Domain),
+      1 * x = x.
+  Proof.
+    intros x.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    unfold Same_set.
+    split; unfold Included; intros t H.
+    - inversion H as [t' H1 H2].
+      assumption.
+    - constructor.
+      + constructor.
+      + assumption.
+  Qed.
 
-Instance Domain_Monoid : Monoid (Mo := Domain_MonoidOps) := {
-    dot_assoc := dot_assoc_domain;
-    dot_neutral_left := dot_neutral_left_domain;
-    dot_neutral_right := dot_neutral_right_domain
-}.
+  Lemma dot_neutral_right_domain : forall (x : Domain),
+      x * 1 = x.
+  Proof.
+    intros x.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    unfold Same_set.
+    split; unfold Included; intros t H.
+    - inversion H as [t' H1 H2].
+      assumption.
+    - constructor.
+      + assumption.
+      + constructor.
+  Qed.
 
-Instance Domain_SemiLatticeOps : SemiLattice_Ops Domain := {
-    zero := fun _ => Empty_set Trace;
-    plus a b := fun i => Union Trace (a i) (b i)
-}.
+  Global Instance Domain_Monoid : Monoid (Mo := Domain_MonoidOps) := {
+      dot_assoc := dot_assoc_domain;
+      dot_neutral_left := dot_neutral_left_domain;
+      dot_neutral_right := dot_neutral_right_domain
+  }.
 
-Instance Domain_LeqOp : Leq_Op Domain := {
-    leq a b := forall i, Included Trace (a i) (b i)
-}.
+  Global Instance Domain_SemiLatticeOps : SemiLattice_Ops Domain := {
+      zero := fun _ => Empty_set Trace;
+      plus a b := fun i => Union Trace (a i) (b i)
+  }.
 
-Lemma domain_leq_refl : forall (x : Domain), x <== x.
-Proof.
-  intros x i.
-  red. intros t H. assumption.
-Qed.
+  Global Instance Domain_LeqOp : Leq_Op Domain := {
+      leq a b := forall i, Included Trace (a i) (b i)
+  }.
 
-Lemma domain_leq_antisym : forall (x y : Domain), 
-    x <== y -> y <== x -> x = y.
-Proof.
-  intros x y Hxy Hyx.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - red. intros t H. apply (Hxy i). assumption.
-  - red. intros t H. apply (Hyx i). assumption.
-Qed.
+  Lemma domain_leq_refl : forall (x : Domain), x <== x.
+  Proof.
+    intros x i.
+    red. intros t H. assumption.
+  Qed.
 
-Lemma domain_leq_trans : forall (x y z : Domain), 
-    x <== y -> y <== z -> x <== z.
-Proof.
-  intros x y z Hxy Hyz i.
-  red. intros t H.
-  apply (Hyz i).
-  apply (Hxy i).
-  assumption.
-Qed.
-
-Instance Domain_PartiallyOrdered : PartiallyOrdered (Lo := Domain_LeqOp) := {
-    leq_refl := domain_leq_refl;
-    leq_antisym := domain_leq_antisym;
-    leq_trans := domain_leq_trans
-}.
-
-Lemma domain_leq_plus_def : forall (x y : Domain), 
-    x <== y <-> x + y = y.
-Proof.
-  intros x y.
-  split.
-  - intro H.
+  Lemma domain_leq_antisym : forall (x y : Domain), 
+      x <== y -> y <== x -> x = y.
+  Proof.
+    intros x y Hxy Hyx.
     extensionality i.
     apply Extensionality_Ensembles.
     split.
-    + intros t H1. inversion H1; [apply (H i) | idtac]; assumption.
-    + intros t H1. apply Union_intror; assumption.
-  - intro H.
-    intros i t H1.
-    assert (H2 : plus x y i = y i) by (rewrite H; reflexivity).
-    simpl in H2.
-    pose proof (Union_introl Trace (x i) (y i) t H1).
-    rewrite H2 in H0.
+    - red. intros t H. apply (Hxy i). assumption.
+    - red. intros t H. apply (Hyx i). assumption.
+  Qed.
+
+  Lemma domain_leq_trans : forall (x y z : Domain), 
+      x <== y -> y <== z -> x <== z.
+  Proof.
+    intros x y z Hxy Hyz i.
+    red. intros t H.
+    apply (Hyz i).
+    apply (Hxy i).
     assumption.
-Qed.
+  Qed.
 
-Lemma domain_plus_neutral_left : forall (x : Domain), 
-    0 + x = x.
-Proof.
-  intros x.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - red; intros t H.
-    inversion H; [inversion H0 | assumption].
-  - red; intros t H.
-    apply Union_intror; assumption.
-Qed.
+  Global Instance Domain_PartiallyOrdered : PartiallyOrdered (Lo := Domain_LeqOp) := {
+      leq_refl := domain_leq_refl;
+      leq_antisym := domain_leq_antisym;
+      leq_trans := domain_leq_trans
+  }.
 
-Lemma domain_plus_idem : forall (x : Domain), 
-    x + x = x.
-Proof.
-  intros x.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - red; intros t H.
-    inversion H; assumption.
-  - red; intros t H.
-    apply Union_introl; assumption.
-Qed.
-
-Lemma domain_plus_assoc : forall (x y z : Domain), 
-    x + (y + z) = (x + y) + z.
-Proof.
-  intros x y z.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - red; intros t H.
-    destruct H as [t H1 | t H1].
-    + apply Union_introl.
-      apply Union_introl.
+  Lemma domain_leq_plus_def : forall (x y : Domain), 
+      x <== y <-> x + y = y.
+  Proof.
+    intros x y.
+    split.
+    - intro H.
+      extensionality i.
+      apply Extensionality_Ensembles.
+      split.
+      + intros t H1. inversion H1; [apply (H i) | idtac]; assumption.
+      + intros t H1. apply Union_intror; assumption.
+    - intro H.
+      intros i t H1.
+      assert (H2 : plus x y i = y i) by (rewrite H; reflexivity).
+      simpl in H2.
+      pose proof (Union_introl Trace (x i) (y i) t H1).
+      rewrite H2 in H0.
       assumption.
-    + destruct H1 as [t H2 | t H2].
-      * apply Union_introl.
-        apply Union_intror.
-        assumption.
-      * apply Union_intror.
-        assumption.
-  - red; intros t H.
-    destruct H as [t H1 | t H1].
-    + destruct H1 as [t H2 | t H2].
-      * apply Union_introl.
-        assumption.
-      * apply Union_intror.
+  Qed.
+
+  Lemma domain_plus_neutral_left : forall (x : Domain), 
+      0 + x = x.
+  Proof.
+    intros x.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split.
+    - red; intros t H.
+      inversion H; [inversion H0 | assumption].
+    - red; intros t H.
+      apply Union_intror; assumption.
+  Qed.
+
+  Lemma domain_plus_idem : forall (x : Domain), 
+      x + x = x.
+  Proof.
+    intros x.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split.
+    - red; intros t H.
+      inversion H; assumption.
+    - red; intros t H.
+      apply Union_introl; assumption.
+  Qed.
+
+  Lemma domain_plus_assoc : forall (x y z : Domain), 
+      x + (y + z) = (x + y) + z.
+  Proof.
+    intros x y z.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split.
+    - red; intros t H.
+      destruct H as [t H1 | t H1].
+      + apply Union_introl.
         apply Union_introl.
         assumption.
-    + apply Union_intror.
-      apply Union_intror.
-      assumption.
-Qed.
+      + destruct H1 as [t H2 | t H2].
+        * apply Union_introl.
+          apply Union_intror.
+          assumption.
+        * apply Union_intror.
+          assumption.
+    - red; intros t H.
+      destruct H as [t H1 | t H1].
+      + destruct H1 as [t H2 | t H2].
+        * apply Union_introl.
+          assumption.
+        * apply Union_intror.
+          apply Union_introl.
+          assumption.
+      + apply Union_intror.
+        apply Union_intror.
+        assumption.
+  Qed.
 
-Lemma domain_plus_com : forall (x y : Domain), 
-    x + y = y + x.
-Proof.
-  intros x y.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - red; intros t H.
-    inversion H; [apply Union_intror | apply Union_introl]; assumption.
-  - red; intros t H.
-    inversion H; [apply Union_intror | apply Union_introl]; assumption.
-Qed.
-
-Lemma domain_plus_monotone_left : forall x y z,
-  x <== y -> z + x <== z + y.
-Proof.
-  intros x y z H.
-  apply domain_leq_plus_def.
-  rewrite domain_leq_plus_def in H.
-  rewrite domain_plus_assoc.
-  rewrite (domain_plus_com (z + x) z).
-  rewrite domain_plus_assoc.
-  rewrite domain_plus_idem.
-  rewrite <- domain_plus_assoc.
-  rewrite H.
-  reflexivity.
-Qed.
-
-Lemma domain_plus_is_lub : forall x y z,
-  x <== z -> y <== z -> x + y <== z.
-Proof.
-  intros x y z H1 H2.
-  apply domain_leq_plus_def.
-  rewrite domain_leq_plus_def in H1.
-  rewrite domain_leq_plus_def in H2.
-  rewrite <- domain_plus_assoc.
-  rewrite H2.
-  rewrite H1.
-  reflexivity.
-Qed.
-
-Instance Domain_SemiLattice : SemiLattice (SLo := Domain_SemiLatticeOps) (Lo := Domain_LeqOp) := {
-    PO_SemiLattice := Domain_PartiallyOrdered;
-    leq_plus_def := domain_leq_plus_def;
-    plus_neutral_left := domain_plus_neutral_left;
-    plus_idem := domain_plus_idem;
-    plus_assoc := domain_plus_assoc;
-    plus_com := domain_plus_com
-}.
-
-Instance Domain_ComplementOp : Complement_Op Domain := {
-    comp a := fun i => Setminus Trace (Full_set Trace) (a i)
-}.
-
-Lemma domain_dot_comm : forall (x y : Domain), x * y = y * x.
-Proof.
-  intros x y.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split; red; intros t H;
-  inversion H; constructor; assumption.
-Qed.
-
-Lemma domain_dot_idem : forall (x : Domain), x * x = x.
-Proof.
-  intros x.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - red; intros t H. inversion H; assumption.
-  - red; intros t H. constructor; assumption.
-Qed.
-
-Lemma domain_distr_dot_plus : forall (x y z : Domain), 
-    x * (y + z) = (x * y) + (x * z).
-Proof.
-  intros x y z.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - red; intros t H.
-    inversion H as [t' H1 H2].
-    inversion H2 as [t'' H3 | t'' H3].
-    + left; constructor; assumption.
-    + right; constructor; assumption.
-  - red; intros t H.
-    inversion H as [t' H1 | t' H1].
-    + inversion H1 as [t'' H2 H3].
-      constructor; [assumption | left; assumption].
-    + inversion H1 as [t'' H2 H3].
-      constructor; [assumption | right; assumption].
-Qed.
-
-Lemma domain_distr_plus_dot : forall (x y z : Domain), 
-    x + (y * z) = (x + y) * (x + z).
-Proof.
-  intros x y z.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - red; intros t H.
-    inversion H as [t' H1 | t' H1].
-    + constructor.
-      * left; assumption.
-      * left; assumption.
-    + inversion H1 as [t'' H2 H3].
-      constructor.
-      * right; assumption.
-      * right; assumption.
-  - red; intros t H.
-    inversion H as [t' H1 H2].
-    inversion H1 as [t'' H3 | t'' H3];
-    inversion H2 as [t''' H5 | t''' H5].
-    + left; assumption.
-    + left; assumption.
-    + left; assumption.
-    + right; constructor; assumption.
-Qed.
-
-Lemma domain_comp_non_contradiction : forall (x : Domain), 
-    x * !x = 0.
-Proof.
-  intros x.
-  extensionality i.
-  unfold Setminus.
-  apply Extensionality_Ensembles.
-  split.
-  - intros t H.
-    destruct H as [t H1 H2].
-    destruct H2 as [H2 H3].
-    contradiction.
-  - intros t H.
-    inversion H.
-Qed.
-
-Lemma domain_comp_excluded_middle : forall (x : Domain), 
-    x + !x = 1.
-Proof.
-  intros x.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - intros t H.
-    destruct H as [t H | t H].
-    + apply Full_intro.
-    + destruct H as [H _]; apply Full_intro.
-  - intros t H.
-  destruct (classic (In Trace (x i) t)) as [H_in | H_not_in].
-  + left; exact H_in.
-  + right; constructor; [apply Full_intro | exact H_not_in].
-Qed.
-
-Instance Domain_BooleanAlgebra : BooleanAlgebra (Mo := Domain_MonoidOps) (SLo := Domain_SemiLatticeOps) (Co := Domain_ComplementOp) (Lo := Domain_LeqOp) := {
-    BA_Monoid := Domain_Monoid;
-    BA_SemiLattice := Domain_SemiLattice;
-    dot_comm := domain_dot_comm;
-    dot_idem := domain_dot_idem;
-    distr_dot_plus := domain_distr_dot_plus;
-    distr_plus_dot := domain_distr_plus_dot;
-    comp_non_contradiction := domain_comp_non_contradiction;
-    comp_excluded_middle := domain_comp_excluded_middle
-}.
-
-Definition domain_lub (X : Ensemble Domain) : Domain :=
-  fun (i : string) (t : Trace) => exists x, In _ X x /\ In _ (x i) t.
-
-Definition domain_glb (X : Ensemble Domain) : Domain :=
-  fun (i : string) (t : Trace) => forall x, In _ X x -> In _ (x i) t.
-
-Lemma Domain_sup_is_lub X : LUB X (domain_lub X).
-Proof.
-  constructor.
-  - intros x Hx i t Ht; exists x; auto.
-  - intros y Hy i t [x [Hx Ht]]; apply (Hy x Hx i); auto.
-Qed.
-
-Lemma Domain_inf_is_glb X : GLB X (domain_glb X).
-Proof.
-  constructor.
-  - intros x Hx i t Ht; apply Ht; auto.
-  - intros y Hy i t Ht x Hx; apply (Hy x Hx i); auto.
-Qed.
-
-Instance Domain_CompleteLattice : CompleteLattice (Lo := Domain_LeqOp) := {
-  PO_CompleteLattice := Domain_PartiallyOrdered;
-  sup := domain_lub;
-  sup_is_lub := Domain_sup_is_lub;
-  inf := domain_glb;
-  inf_is_glb := Domain_inf_is_glb;
-}.
-
-Lemma domain_lub_empty : domain_lub (Empty_set Domain) = zero.
-Proof.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - intros t H. destruct H as [l [l' r]]. contradiction. 
-  - intros t H. contradiction.
-Qed.
-
-Lemma domain_lub_singleton : forall x, domain_lub (Singleton Domain x) = x.
-Proof.
-  intros x.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - intros t H. destruct H as [h [l r]]. apply Singleton_inv in l.
-    rewrite <- l in r.
-    assumption.
-  - intros t H.
-    exists x.
+  Lemma domain_plus_com : forall (x y : Domain), 
+      x + y = y + x.
+  Proof.
+    intros x y.
+    extensionality i.
+    apply Extensionality_Ensembles.
     split.
-    + reflexivity.
-    + assumption.
-Qed.
+    - red; intros t H.
+      inversion H; [apply Union_intror | apply Union_introl]; assumption.
+    - red; intros t H.
+      inversion H; [apply Union_intror | apply Union_introl]; assumption.
+  Qed.
 
-Lemma domain_lub_union : forall A B, 
-  domain_lub (Union Domain A B) = (domain_lub A) + (domain_lub B).
-Proof.
-  intros A B.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - intros t H. destruct H.
-    destruct H as [H_union H_trace].
-    destruct H_union as [x_in_A | x_in_B].
-    + left.
-      exists x_in_A.
-      split; assumption.
-    + right.
-      exists x_in_B.
-      split; assumption.
-  - red. intros. red in H. red.  
-    destruct H as [x H | x H].
-    + destruct H as [d [H_A H_trace]].
-      exists d.
+  Lemma domain_plus_monotone_left : forall x y z,
+    x <== y -> z + x <== z + y.
+  Proof.
+    intros x y z H.
+    apply domain_leq_plus_def.
+    rewrite domain_leq_plus_def in H.
+    rewrite domain_plus_assoc.
+    rewrite (domain_plus_com (z + x) z).
+    rewrite domain_plus_assoc.
+    rewrite domain_plus_idem.
+    rewrite <- domain_plus_assoc.
+    rewrite H.
+    reflexivity.
+  Qed.
+
+  Lemma domain_plus_is_lub : forall x y z,
+    x <== z -> y <== z -> x + y <== z.
+  Proof.
+    intros x y z H1 H2.
+    apply domain_leq_plus_def.
+    rewrite domain_leq_plus_def in H1.
+    rewrite domain_leq_plus_def in H2.
+    rewrite <- domain_plus_assoc.
+    rewrite H2.
+    rewrite H1.
+    reflexivity.
+  Qed.
+
+  Global Instance Domain_SemiLattice : SemiLattice (SLo := Domain_SemiLatticeOps) (Lo := Domain_LeqOp) := {
+      PO_SemiLattice := Domain_PartiallyOrdered;
+      leq_plus_def := domain_leq_plus_def;
+      plus_neutral_left := domain_plus_neutral_left;
+      plus_idem := domain_plus_idem;
+      plus_assoc := domain_plus_assoc;
+      plus_com := domain_plus_com
+  }.
+
+  Global Instance Domain_ComplementOp : Complement_Op Domain := {
+      comp a := fun i => Setminus Trace (Full_set Trace) (a i)
+  }.
+
+  Lemma domain_dot_comm : forall (x y : Domain), x * y = y * x.
+  Proof.
+    intros x y.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split; red; intros t H;
+    inversion H; constructor; assumption.
+  Qed.
+
+  Lemma domain_dot_idem : forall (x : Domain), x * x = x.
+  Proof.
+    intros x.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split.
+    - red; intros t H. inversion H; assumption.
+    - red; intros t H. constructor; assumption.
+  Qed.
+
+  Lemma domain_distr_dot_plus : forall (x y z : Domain), 
+      x * (y + z) = (x * y) + (x * z).
+  Proof.
+    intros x y z.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split.
+    - red; intros t H.
+      inversion H as [t' H1 H2].
+      inversion H2 as [t'' H3 | t'' H3].
+      + left; constructor; assumption.
+      + right; constructor; assumption.
+    - red; intros t H.
+      inversion H as [t' H1 | t' H1].
+      + inversion H1 as [t'' H2 H3].
+        constructor; [assumption | left; assumption].
+      + inversion H1 as [t'' H2 H3].
+        constructor; [assumption | right; assumption].
+  Qed.
+
+  Lemma domain_distr_plus_dot : forall (x y z : Domain), 
+      x + (y * z) = (x + y) * (x + z).
+  Proof.
+    intros x y z.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split.
+    - red; intros t H.
+      inversion H as [t' H1 | t' H1].
+      + constructor.
+        * left; assumption.
+        * left; assumption.
+      + inversion H1 as [t'' H2 H3].
+        constructor.
+        * right; assumption.
+        * right; assumption.
+    - red; intros t H.
+      inversion H as [t' H1 H2].
+      inversion H1 as [t'' H3 | t'' H3];
+      inversion H2 as [t''' H5 | t''' H5].
+      + left; assumption.
+      + left; assumption.
+      + left; assumption.
+      + right; constructor; assumption.
+  Qed.
+
+  Lemma domain_comp_non_contradiction : forall (x : Domain), 
+      x * !x = 0.
+  Proof.
+    intros x.
+    extensionality i.
+    unfold Setminus.
+    apply Extensionality_Ensembles.
+    split.
+    - intros t H.
+      destruct H as [t H1 H2].
+      destruct H2 as [H2 H3].
+      contradiction.
+    - intros t H.
+      inversion H.
+  Qed.
+
+  Lemma domain_comp_excluded_middle : forall (x : Domain), 
+      x + !x = 1.
+  Proof.
+    intros x.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split.
+    - intros t H.
+      destruct H as [t H | t H].
+      + apply Full_intro.
+      + destruct H as [H _]; apply Full_intro.
+    - intros t H.
+    destruct (classic (In Trace (x i) t)) as [H_in | H_not_in].
+    + left; exact H_in.
+    + right; constructor; [apply Full_intro | exact H_not_in].
+  Qed.
+
+  Global Instance Domain_BooleanAlgebra : BooleanAlgebra (Mo := Domain_MonoidOps) (SLo := Domain_SemiLatticeOps) (Co := Domain_ComplementOp) (Lo := Domain_LeqOp) := {
+      BA_Monoid := Domain_Monoid;
+      BA_SemiLattice := Domain_SemiLattice;
+      dot_comm := domain_dot_comm;
+      dot_idem := domain_dot_idem;
+      distr_dot_plus := domain_distr_dot_plus;
+      distr_plus_dot := domain_distr_plus_dot;
+      comp_non_contradiction := domain_comp_non_contradiction;
+      comp_excluded_middle := domain_comp_excluded_middle
+  }.
+
+  Definition domain_lub (X : Ensemble Domain) : Domain :=
+    fun (i : list Σ) (t : Trace) => exists x, In _ X x /\ In _ (x i) t.
+
+  Definition domain_glb (X : Ensemble Domain) : Domain :=
+    fun (i : list Σ) (t : Trace) => forall x, In _ X x -> In _ (x i) t.
+
+  Lemma Domain_sup_is_lub X : LUB X (domain_lub X).
+  Proof.
+    constructor.
+    - intros x Hx i t Ht; exists x; auto.
+    - intros y Hy i t [x [Hx Ht]]; apply (Hy x Hx i); auto.
+  Qed.
+
+  Lemma Domain_inf_is_glb X : GLB X (domain_glb X).
+  Proof.
+    constructor.
+    - intros x Hx i t Ht; apply Ht; auto.
+    - intros y Hy i t Ht x Hx; apply (Hy x Hx i); auto.
+  Qed.
+
+  Global Instance Domain_CompleteLattice : CompleteLattice (Lo := Domain_LeqOp) := {
+    PO_CompleteLattice := Domain_PartiallyOrdered;
+    sup := domain_lub;
+    sup_is_lub := Domain_sup_is_lub;
+    inf := domain_glb;
+    inf_is_glb := Domain_inf_is_glb;
+  }.
+
+  Lemma domain_lub_empty : domain_lub (Empty_set Domain) = zero.
+  Proof.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split.
+    - intros t H. destruct H as [l [l' r]]. contradiction. 
+    - intros t H. contradiction.
+  Qed.
+
+  Lemma domain_lub_singleton : forall x, domain_lub (Singleton Domain x) = x.
+  Proof.
+    intros x.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split.
+    - intros t H. destruct H as [h [l r]]. apply Singleton_inv in l.
+      rewrite <- l in r.
+      assumption.
+    - intros t H.
+      exists x.
       split.
-      ++ left; assumption.
+      + reflexivity.
+      + assumption.
+  Qed.
+
+  Lemma domain_lub_union : forall A B, 
+    domain_lub (Union Domain A B) = (domain_lub A) + (domain_lub B).
+  Proof.
+    intros A B.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split.
+    - intros t H. destruct H.
+      destruct H as [H_union H_trace].
+      destruct H_union as [x_in_A | x_in_B].
+      + left.
+        exists x_in_A.
+        split; assumption.
+      + right.
+        exists x_in_B.
+        split; assumption.
+    - red. intros. red in H. red.  
+      destruct H as [x H | x H].
+      + destruct H as [d [H_A H_trace]].
+        exists d.
+        split.
+        ++ left; assumption.
+        ++ assumption.
+      + destruct H as [d [H_B H_trace]].
+        exists d.
+        split.
+      ++ right; assumption.
       ++ assumption.
-    + destruct H as [d [H_B H_trace]].
-      exists d.
-      split.
-    ++ right; assumption.
-    ++ assumption.
-Qed.
+  Qed.
+
+End Domain.

--- a/src/Domain.v
+++ b/src/Domain.v
@@ -2,7 +2,7 @@ From klenee_complexity Require Import Algebraic_Structures TM.
 From Coq Require Import Logic.Classical Sets.Powerset Logic.FunctionalExtensionality Sets.Constructive_sets.
 
 Section Domain.
-  Context `{params : TMParams}.
+  Context `{tm : TM}.
 
   Definition Domain := list Σ -> Ensemble Trace.
 

--- a/src/Domain.v
+++ b/src/Domain.v
@@ -1,237 +1,243 @@
-From klenee_complexity Require Import Algebraic_Structures Conf.
-From Coq Require Import Strings.String Logic.Classical Sets.Powerset Logic.FunctionalExtensionality Sets.Constructive_sets.
+From klenee_complexity Require Import Algebraic_Structures TM.
+From Coq Require Import Logic.Classical Sets.Powerset Logic.FunctionalExtensionality Sets.Constructive_sets.
 
-Definition Domain := string -> Ensemble Trace.
+Section Domain.
+  Context `{tm : TM}.
 
-Instance Domain_MonoidOps : Monoid_Ops Domain := {
-    one := fun _ => Full_set Trace;
-    dot a b := fun i => Intersection Trace (a i) (b i)
-}.
 
-Instance Domain_SemiLatticeOps : SemiLattice_Ops Domain := {
-    zero := fun _ => Empty_set Trace;
-    plus a b := fun i => Union Trace (a i) (b i)
-}.
+  Definition Domain := list Σ -> Ensemble Trace.
 
-Instance Domain_LeqOp : Leq_Op Domain := {
-    leq a b := forall i, Included Trace (a i) (b i)
-}.
+  Global Instance Domain_MonoidOps : Monoid_Ops Domain := {
+      one := fun _ => Full_set Trace;
+      dot a b := fun i => Intersection Trace (a i) (b i)
+  }.
 
-Instance Domain_ComplementOp : Complement_Op Domain := {
-    comp a := fun i => Setminus Trace (Full_set Trace) (a i)
-}.
+  Global Instance Domain_SemiLatticeOps : SemiLattice_Ops Domain := {
+      zero := fun _ => Empty_set Trace;
+      plus a b := fun i => Union Trace (a i) (b i)
+  }.
 
-Ltac ens_step :=
-  match goal with
-  | [ H : In _ _ _             |- _ ] => red in H
-  | [ H : Union _ _ _ _        |- _ ] => destruct H
-  | [ H : Intersection _ _ _ _ |- _ ] => destruct H
-  | [ H : Setminus _ _ _ _     |- _ ] => destruct H
-  | [ H : Empty_set _ _        |- _ ] => destruct H
-  | [ |- In _ (Intersection _ _ _) _ ] => constructor
-  | [ |- In _ (Setminus _ _ _) _     ] => constructor
-  | [ |- In _ (Full_set _) _         ] => constructor
-  end.
+  Global Instance Domain_LeqOp : Leq_Op Domain := {
+      leq a b := forall i, Included Trace (a i) (b i)
+  }.
 
-Ltac domain_ext :=
-  extensionality i; apply Extensionality_Ensembles; split;
-  intros t Ht; unfold Included in *; simpl in *;
-  repeat ens_step; try contradiction; auto with sets.
+  Global Instance Domain_ComplementOp : Complement_Op Domain := {
+      comp a := fun i => Setminus Trace (Full_set Trace) (a i)
+  }.
 
-Lemma dot_assoc_domain : forall (x y z : Domain),
-    x * (y * z) = (x * y) * z.
-Proof. intros x y z; domain_ext. Qed.
+  Ltac ens_step :=
+    match goal with
+    | [ H : In _ _ _             |- _ ] => red in H
+    | [ H : Union _ _ _ _        |- _ ] => destruct H
+    | [ H : Intersection _ _ _ _ |- _ ] => destruct H
+    | [ H : Setminus _ _ _ _     |- _ ] => destruct H
+    | [ H : Empty_set _ _        |- _ ] => destruct H
+    | [ |- In _ (Intersection _ _ _) _ ] => constructor
+    | [ |- In _ (Setminus _ _ _) _     ] => constructor
+    | [ |- In _ (Full_set _) _         ] => constructor
+    end.
 
-Lemma dot_neutral_left_domain : forall (x : Domain),
-    1 * x = x.
-Proof. intros x; domain_ext. Qed.
+  Ltac domain_ext :=
+    extensionality i; apply Extensionality_Ensembles; split;
+    intros t Ht; unfold Included in *; simpl in *;
+    repeat ens_step; try contradiction; auto with sets.
 
-Lemma dot_neutral_right_domain : forall (x : Domain),
-    x * 1 = x.
-Proof. intros x; domain_ext. Qed.
+  Lemma dot_assoc_domain : forall (x y z : Domain),
+      x * (y * z) = (x * y) * z.
+  Proof. intros x y z; domain_ext. Qed.
 
-Instance Domain_Monoid : Monoid (Mo := Domain_MonoidOps) := {
-    dot_assoc := dot_assoc_domain;
-    dot_neutral_left := dot_neutral_left_domain;
-    dot_neutral_right := dot_neutral_right_domain
-}.
+  Lemma dot_neutral_left_domain : forall (x : Domain),
+      1 * x = x.
+  Proof. intros x; domain_ext. Qed.
 
-Lemma domain_leq_refl : forall (x : Domain), x <== x.
-Proof. intros x i t H; assumption. Qed.
+  Lemma dot_neutral_right_domain : forall (x : Domain),
+      x * 1 = x.
+  Proof. intros x; domain_ext. Qed.
 
-Lemma domain_leq_antisym : forall (x y : Domain),
-    x <== y -> y <== x -> x = y.
-Proof.
-  intros x y Hxy Hyx.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split; [apply Hxy | apply Hyx].
-Qed.
+  Global Instance Domain_Monoid : Monoid (Mo := Domain_MonoidOps) := {
+      dot_assoc := dot_assoc_domain;
+      dot_neutral_left := dot_neutral_left_domain;
+      dot_neutral_right := dot_neutral_right_domain
+  }.
 
-Lemma domain_leq_trans : forall (x y z : Domain),
-    x <== y -> y <== z -> x <== z.
-Proof.
-  intros x y z Hxy Hyz i t H.
-  apply (Hyz i), (Hxy i), H.
-Qed.
+  Lemma domain_leq_refl : forall (x : Domain), x <== x.
+  Proof. intros x i t H; assumption. Qed.
 
-Instance Domain_PartiallyOrdered : PartiallyOrdered (Lo := Domain_LeqOp) := {
-    leq_refl := domain_leq_refl;
-    leq_antisym := domain_leq_antisym;
-    leq_trans := domain_leq_trans
-}.
+  Lemma domain_leq_antisym : forall (x y : Domain),
+      x <== y -> y <== x -> x = y.
+  Proof.
+    intros x y Hxy Hyx.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split; [apply Hxy | apply Hyx].
+  Qed.
 
-Lemma domain_leq_plus_def : forall (x y : Domain),
-    x <== y <-> x + y = y.
-Proof.
-  intros x y; split.
-  - intro H.
+  Lemma domain_leq_trans : forall (x y z : Domain),
+      x <== y -> y <== z -> x <== z.
+  Proof.
+    intros x y z Hxy Hyz i t H.
+    apply (Hyz i), (Hxy i), H.
+  Qed.
+
+  Global Instance Domain_PartiallyOrdered : PartiallyOrdered (Lo := Domain_LeqOp) := {
+      leq_refl := domain_leq_refl;
+      leq_antisym := domain_leq_antisym;
+      leq_trans := domain_leq_trans
+  }.
+
+  Lemma domain_leq_plus_def : forall (x y : Domain),
+      x <== y <-> x + y = y.
+  Proof.
+    intros x y; split.
+    - intro H.
+      extensionality i.
+      apply Extensionality_Ensembles; split; intros t Ht.
+      + destruct Ht as [t Ht | t Ht]; [apply (H i) | ]; exact Ht.
+      + apply Union_intror, Ht.
+    - intros H i t Ht.
+      rewrite <- H.
+      apply Union_introl, Ht.
+  Qed.
+
+  Lemma domain_plus_neutral_left : forall (x : Domain),
+      0 + x = x.
+  Proof. intros x; domain_ext. Qed.
+
+  Lemma domain_plus_idem : forall (x : Domain),
+      x + x = x.
+  Proof. intros x; domain_ext. Qed.
+
+  Lemma domain_plus_assoc : forall (x y z : Domain),
+      x + (y + z) = (x + y) + z.
+  Proof. intros x y z; domain_ext. Qed.
+
+  Lemma domain_plus_com : forall (x y : Domain),
+      x + y = y + x.
+  Proof. intros x y; domain_ext. Qed.
+
+  Lemma domain_plus_monotone_left : forall x y z,
+    x <== y -> z + x <== z + y.
+  Proof.
+    intros x y z H i t Ht.
+    destruct Ht as [t Ht | t Ht].
+    - apply Union_introl, Ht.
+    - apply Union_intror, (H i), Ht.
+  Qed.
+
+  Lemma domain_plus_is_lub : forall x y z,
+    x <== z -> y <== z -> x + y <== z.
+  Proof.
+    intros x y z H1 H2 i t Ht.
+    destruct Ht as [t Ht | t Ht]; [apply (H1 i) | apply (H2 i)]; exact Ht.
+  Qed.
+
+  Lemma domain_leq_plus_left : forall (x y : Domain), x <== x + y.
+  Proof.
+    intros x y; apply domain_leq_plus_def.
+    now rewrite domain_plus_assoc, domain_plus_idem.
+  Qed.
+
+  Lemma domain_leq_plus_right : forall (x y : Domain), y <== x + y.
+  Proof.
+    intros x y; rewrite domain_plus_com; apply domain_leq_plus_left.
+  Qed.
+
+  Global Instance Domain_SemiLattice : SemiLattice (SLo := Domain_SemiLatticeOps) (Lo := Domain_LeqOp) := {
+      PO_SemiLattice := Domain_PartiallyOrdered;
+      leq_plus_def := domain_leq_plus_def;
+      plus_neutral_left := domain_plus_neutral_left;
+      plus_idem := domain_plus_idem;
+      plus_assoc := domain_plus_assoc;
+      plus_com := domain_plus_com
+  }.
+
+  Lemma domain_dot_comm : forall (x y : Domain), x * y = y * x.
+  Proof. intros x y; domain_ext. Qed.
+
+  Lemma domain_dot_idem : forall (x : Domain), x * x = x.
+  Proof. intros x; domain_ext. Qed.
+
+  Lemma domain_distr_dot_plus : forall (x y z : Domain),
+      x * (y + z) = (x * y) + (x * z).
+  Proof. intros x y z; domain_ext. Qed.
+
+  Lemma domain_distr_plus_dot : forall (x y z : Domain),
+      x + (y * z) = (x + y) * (x + z).
+  Proof. intros x y z; domain_ext. Qed.
+
+  Lemma domain_comp_non_contradiction : forall (x : Domain),
+      x * !x = 0.
+  Proof. intros x; domain_ext. Qed.
+
+  Lemma domain_comp_excluded_middle : forall (x : Domain),
+      x + !x = 1.
+  Proof.
+    intros x; domain_ext.
+    destruct (classic (In Trace (x i) t)); auto with sets.
+  Qed.
+
+  Global Instance Domain_BooleanAlgebra : BooleanAlgebra (Mo := Domain_MonoidOps) (SLo := Domain_SemiLatticeOps) (Co := Domain_ComplementOp) (Lo := Domain_LeqOp) := {
+      BA_Monoid := Domain_Monoid;
+      BA_SemiLattice := Domain_SemiLattice;
+      dot_comm := domain_dot_comm;
+      dot_idem := domain_dot_idem;
+      distr_dot_plus := domain_distr_dot_plus;
+      distr_plus_dot := domain_distr_plus_dot;
+      comp_non_contradiction := domain_comp_non_contradiction;
+      comp_excluded_middle := domain_comp_excluded_middle
+  }.
+
+  Definition domain_lub (X : Ensemble Domain) : Domain :=
+    fun (i : list Σ) (t : Trace) => exists x, In _ X x /\ In _ (x i) t.
+
+  Definition domain_glb (X : Ensemble Domain) : Domain :=
+    fun (i : list Σ) (t : Trace) => forall x, In _ X x -> In _ (x i) t.
+
+  Lemma Domain_sup_is_lub X : LUB X (domain_lub X).
+  Proof.
+    constructor.
+    - intros x Hx i t Ht; exists x; auto.
+    - intros y Hy i t [x [Hx Ht]]; apply (Hy x Hx i); auto.
+  Qed.
+
+  Lemma Domain_inf_is_glb X : GLB X (domain_glb X).
+  Proof.
+    constructor.
+    - intros x Hx i t Ht; apply Ht; auto.
+    - intros y Hy i t Ht x Hx; apply (Hy x Hx i); auto.
+  Qed.
+
+  Global Instance Domain_CompleteLattice : CompleteLattice (Lo := Domain_LeqOp) := {
+    PO_CompleteLattice := Domain_PartiallyOrdered;
+    sup := domain_lub;
+    sup_is_lub := Domain_sup_is_lub;
+    inf := domain_glb;
+    inf_is_glb := Domain_inf_is_glb;
+  }.
+
+  Lemma domain_lub_empty : domain_lub (Empty_set Domain) = zero.
+  Proof. domain_ext; firstorder. Qed.
+
+  Lemma domain_lub_singleton : forall x, domain_lub (Singleton Domain x) = x.
+  Proof.
+    intros x.
     extensionality i.
     apply Extensionality_Ensembles; split; intros t Ht.
-    + destruct Ht as [t Ht | t Ht]; [apply (H i) | ]; exact Ht.
-    + apply Union_intror, Ht.
-  - intros H i t Ht.
-    rewrite <- H.
-    apply Union_introl, Ht.
-Qed.
+    - destruct Ht as [d [Hd Ht]].
+      apply Singleton_inv in Hd; subst; assumption.
+    - exists x; split; [constructor | assumption].
+  Qed.
 
-Lemma domain_plus_neutral_left : forall (x : Domain),
-    0 + x = x.
-Proof. intros x; domain_ext. Qed.
+  Lemma domain_lub_union : forall A B,
+    domain_lub (Union Domain A B) = (domain_lub A) + (domain_lub B).
+  Proof.
+    intros A B.
+    extensionality i.
+    apply Extensionality_Ensembles; split; intros t Ht.
+    - destruct Ht as [d [Hd Ht]].
+      destruct Hd as [d Hd | d Hd]; [left | right]; exists d; auto.
+    - destruct Ht as [t Ht | t Ht]; destruct Ht as [d [Hd Ht]];
+        exists d; split; auto with sets.
+  Qed.
 
-Lemma domain_plus_idem : forall (x : Domain),
-    x + x = x.
-Proof. intros x; domain_ext. Qed.
-
-Lemma domain_plus_assoc : forall (x y z : Domain),
-    x + (y + z) = (x + y) + z.
-Proof. intros x y z; domain_ext. Qed.
-
-Lemma domain_plus_com : forall (x y : Domain),
-    x + y = y + x.
-Proof. intros x y; domain_ext. Qed.
-
-Lemma domain_plus_monotone_left : forall x y z,
-  x <== y -> z + x <== z + y.
-Proof.
-  intros x y z H i t Ht.
-  destruct Ht as [t Ht | t Ht].
-  - apply Union_introl, Ht.
-  - apply Union_intror, (H i), Ht.
-Qed.
-
-Lemma domain_plus_is_lub : forall x y z,
-  x <== z -> y <== z -> x + y <== z.
-Proof.
-  intros x y z H1 H2 i t Ht.
-  destruct Ht as [t Ht | t Ht]; [apply (H1 i) | apply (H2 i)]; exact Ht.
-Qed.
-
-Lemma domain_leq_plus_left : forall (x y : Domain), x <== x + y.
-Proof.
-  intros x y; apply domain_leq_plus_def.
-  now rewrite domain_plus_assoc, domain_plus_idem.
-Qed.
-
-Lemma domain_leq_plus_right : forall (x y : Domain), y <== x + y.
-Proof.
-  intros x y; rewrite domain_plus_com; apply domain_leq_plus_left.
-Qed.
-
-Instance Domain_SemiLattice : SemiLattice (SLo := Domain_SemiLatticeOps) (Lo := Domain_LeqOp) := {
-    PO_SemiLattice := Domain_PartiallyOrdered;
-    leq_plus_def := domain_leq_plus_def;
-    plus_neutral_left := domain_plus_neutral_left;
-    plus_idem := domain_plus_idem;
-    plus_assoc := domain_plus_assoc;
-    plus_com := domain_plus_com
-}.
-
-Lemma domain_dot_comm : forall (x y : Domain), x * y = y * x.
-Proof. intros x y; domain_ext. Qed.
-
-Lemma domain_dot_idem : forall (x : Domain), x * x = x.
-Proof. intros x; domain_ext. Qed.
-
-Lemma domain_distr_dot_plus : forall (x y z : Domain),
-    x * (y + z) = (x * y) + (x * z).
-Proof. intros x y z; domain_ext. Qed.
-
-Lemma domain_distr_plus_dot : forall (x y z : Domain),
-    x + (y * z) = (x + y) * (x + z).
-Proof. intros x y z; domain_ext. Qed.
-
-Lemma domain_comp_non_contradiction : forall (x : Domain),
-    x * !x = 0.
-Proof. intros x; domain_ext. Qed.
-
-Lemma domain_comp_excluded_middle : forall (x : Domain),
-    x + !x = 1.
-Proof.
-  intros x; domain_ext.
-  destruct (classic (In Trace (x i) t)); auto with sets.
-Qed.
-
-Instance Domain_BooleanAlgebra : BooleanAlgebra (Mo := Domain_MonoidOps) (SLo := Domain_SemiLatticeOps) (Co := Domain_ComplementOp) (Lo := Domain_LeqOp) := {
-    BA_Monoid := Domain_Monoid;
-    BA_SemiLattice := Domain_SemiLattice;
-    dot_comm := domain_dot_comm;
-    dot_idem := domain_dot_idem;
-    distr_dot_plus := domain_distr_dot_plus;
-    distr_plus_dot := domain_distr_plus_dot;
-    comp_non_contradiction := domain_comp_non_contradiction;
-    comp_excluded_middle := domain_comp_excluded_middle
-}.
-
-Definition domain_lub (X : Ensemble Domain) : Domain :=
-  fun (i : string) (t : Trace) => exists x, In _ X x /\ In _ (x i) t.
-
-Definition domain_glb (X : Ensemble Domain) : Domain :=
-  fun (i : string) (t : Trace) => forall x, In _ X x -> In _ (x i) t.
-
-Lemma Domain_sup_is_lub X : LUB X (domain_lub X).
-Proof.
-  constructor.
-  - intros x Hx i t Ht; exists x; auto.
-  - intros y Hy i t [x [Hx Ht]]; apply (Hy x Hx i); auto.
-Qed.
-
-Lemma Domain_inf_is_glb X : GLB X (domain_glb X).
-Proof.
-  constructor.
-  - intros x Hx i t Ht; apply Ht; auto.
-  - intros y Hy i t Ht x Hx; apply (Hy x Hx i); auto.
-Qed.
-
-Instance Domain_CompleteLattice : CompleteLattice (Lo := Domain_LeqOp) := {
-  PO_CompleteLattice := Domain_PartiallyOrdered;
-  sup := domain_lub;
-  sup_is_lub := Domain_sup_is_lub;
-  inf := domain_glb;
-  inf_is_glb := Domain_inf_is_glb;
-}.
-
-Lemma domain_lub_empty : domain_lub (Empty_set Domain) = zero.
-Proof. domain_ext; firstorder. Qed.
-
-Lemma domain_lub_singleton : forall x, domain_lub (Singleton Domain x) = x.
-Proof.
-  intros x.
-  extensionality i.
-  apply Extensionality_Ensembles; split; intros t Ht.
-  - destruct Ht as [d [Hd Ht]].
-    apply Singleton_inv in Hd; subst; assumption.
-  - exists x; split; [constructor | assumption].
-Qed.
-
-Lemma domain_lub_union : forall A B,
-  domain_lub (Union Domain A B) = (domain_lub A) + (domain_lub B).
-Proof.
-  intros A B.
-  extensionality i.
-  apply Extensionality_Ensembles; split; intros t Ht.
-  - destruct Ht as [d [Hd Ht]].
-    destruct Hd as [d Hd | d Hd]; [left | right]; exists d; auto.
-  - destruct Ht as [t Ht | t Ht]; destruct Ht as [d [Hd Ht]];
-      exists d; split; auto with sets.
-Qed.
+End Domain.

--- a/src/Endo.v
+++ b/src/Endo.v
@@ -1,717 +1,723 @@
-From klenee_complexity Require Import Algebraic_Structures Domain Conf LFP NEList.
-From Coq Require Import Program.Basics Strings.String.
+From klenee_complexity Require Import Algebraic_Structures Domain TM LFP NEList.
+From Coq Require Import Program.Basics.
 From Coq Require Import Sets.Powerset Sets.Image.
 From Coq Require Import Logic.FunctionalExtensionality.
 
-Definition Endo := Domain -> Domain.
+Section Endo.
+  Context `{params : TMParams}.
 
-Axiom endo_monotone : forall (z : Endo) (f g : Domain),
-    f <== g -> z f <== z g.
+  Definition Endo := Domain -> Domain.
 
-Definition СontinuousEndo := Endo.
+  Axiom endo_monotone : forall (z : Endo) (f g : Domain),
+      f <== g -> z f <== z g.
 
-Axiom endo_continuous : forall (a : СontinuousEndo) (X : Ensemble Domain),
-    a (domain_lub X) = domain_lub (Im _ _ X a).
+  Definition СontinuousEndo := Endo.
 
-Lemma endo_continuous_binary : forall (a : СontinuousEndo) (x y : Domain),
-    a (x + y) = a x + a y.
-Proof.
-  intros a x y.
-  assert (H : x + y = domain_lub (Union _ (Singleton _ x) (Singleton _ y))).
-  {
+  Axiom endo_continuous : forall (a : СontinuousEndo) (X : Ensemble Domain),
+      a (domain_lub X) = domain_lub (Im _ _ X a).
+
+  Lemma endo_continuous_binary : forall (a : СontinuousEndo) (x y : Domain),
+      a (x + y) = a x + a y.
+  Proof.
+    intros a x y.
+    assert (H : x + y = domain_lub (Union _ (Singleton _ x) (Singleton _ y))).
+    {
+      rewrite domain_lub_union.
+      rewrite domain_lub_singleton.
+      rewrite domain_lub_singleton.
+      reflexivity.
+    }
+    rewrite H.
+    
+    rewrite endo_continuous.
+    
+    assert (Im_eq : Im _ _ (Union _ (Singleton _ x) (Singleton _ y)) a = 
+                Union _ (Singleton _ (a x)) (Singleton _ (a y))).
+    {
+      apply Extensionality_Ensembles.
+      split.
+      - intros z Hz.
+        destruct Hz as [w Hw].
+        destruct Hw as [w Hw|w Hw].
+        + destruct Hw. left. red. rewrite <- H0. constructor.
+        + destruct Hw. right. red. rewrite <- H0. constructor.
+      - intros z Hz.
+        destruct Hz as [z Hz|z Hz].
+        + destruct Hz. apply Im_intro with x.
+          * left. constructor.
+          * reflexivity.
+        + destruct Hz. apply Im_intro with y.
+          * right. constructor.
+          * reflexivity.
+    }
+    rewrite Im_eq.
+    
     rewrite domain_lub_union.
     rewrite domain_lub_singleton.
     rewrite domain_lub_singleton.
     reflexivity.
-  }
-  rewrite H.
-  
-  rewrite endo_continuous.
-  
-  assert (Im_eq : Im _ _ (Union _ (Singleton _ x) (Singleton _ y)) a = 
-              Union _ (Singleton _ (a x)) (Singleton _ (a y))).
-  {
+  Qed.
+
+  Global Instance Endo_MonoidOps : Monoid_Ops Endo := {
+      one := id;
+      dot := compose; 
+  }.
+
+  Global Instance Endo_Monoid : Monoid (Mo := Endo_MonoidOps) := {
+      dot_assoc := fun x y z => eq_refl;
+      dot_neutral_left := fun x => eq_refl;
+      dot_neutral_right := fun x => eq_refl;
+  }.
+
+  Global Instance Endo_SemiLatticeOps : SemiLattice_Ops Endo := {
+    zero := fun _ => zero;
+    plus a b := fun d => a d + b d;
+  }.
+
+  Global Instance Endo_LeqOp : Leq_Op Endo := {
+      leq a b := a + b = b
+  }.
+
+  Lemma endo_leq_refl : forall (a : Endo), a <== a.
+  Proof.
+    intro a.
+    apply functional_extensionality.
+    intro d.
+    apply domain_plus_idem.
+  Qed.
+
+  Lemma endo_leq_antisym : forall (x y : Endo), 
+      x <== y -> y <== x -> x = y.
+  Proof.
+    intros x y Hxy Hyx.
+    extensionality d.
+    extensionality i.
     apply Extensionality_Ensembles.
     split.
-    - intros z Hz.
-      destruct Hz as [w Hw].
-      destruct Hw as [w Hw|w Hw].
-      + destruct Hw. left. red. rewrite <- H0. constructor.
-      + destruct Hw. right. red. rewrite <- H0. constructor.
-    - intros z Hz.
-      destruct Hz as [z Hz|z Hz].
-      + destruct Hz. apply Im_intro with x.
-        * left. constructor.
-        * reflexivity.
-      + destruct Hz. apply Im_intro with y.
-        * right. constructor.
-        * reflexivity.
-  }
-  rewrite Im_eq.
-  
-  rewrite domain_lub_union.
-  rewrite domain_lub_singleton.
-  rewrite domain_lub_singleton.
-  reflexivity.
-Qed.
+    - intros t Ht.
+      apply (f_equal (fun f => f d i)) in Hxy.
+      simpl in Hxy.
+      assert (H : In Trace (Union Trace (x d i) (y d i)) t).
+      { apply Union_introl; assumption. }
+      rewrite Hxy in H.
+      assumption.
+    - intros t Ht.
+      apply (f_equal (fun f => f d i)) in Hyx.
+      simpl in Hyx.
+      assert (H : In Trace (Union Trace (y d i) (x d i)) t).
+      { apply Union_introl; assumption. }
+      rewrite Hyx in H.
+      assumption.
+  Qed.
 
-Instance Endo_MonoidOps : Monoid_Ops Endo := {
-    one := id;
-    dot := compose; 
-}.
-
-Instance Endo_Monoid : Monoid (Mo := Endo_MonoidOps) := {
-    dot_assoc := fun x y z => eq_refl;
-    dot_neutral_left := fun x => eq_refl;
-    dot_neutral_right := fun x => eq_refl;
-}.
-
-Instance Endo_SemiLatticeOps : SemiLattice_Ops Endo := {
-  zero := fun _ => zero;
-  plus a b := fun d => a d + b d;
-}.
-
-Instance Endo_LeqOp : Leq_Op Endo := {
-    leq a b := a + b = b
-}.
-
-Lemma endo_leq_refl : forall (a : Endo), a <== a.
-Proof.
-  intro a.
-  apply functional_extensionality.
-  intro d.
-  apply domain_plus_idem.
-Qed.
-
-Lemma endo_leq_antisym : forall (x y : Endo), 
-    x <== y -> y <== x -> x = y.
-Proof.
-  intros x y Hxy Hyx.
-  extensionality d.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - intros t Ht.
-    apply (f_equal (fun f => f d i)) in Hxy.
-    simpl in Hxy.
-    assert (H : In Trace (Union Trace (x d i) (y d i)) t).
-    { apply Union_introl; assumption. }
-    rewrite Hxy in H.
-    assumption.
-  - intros t Ht.
-    apply (f_equal (fun f => f d i)) in Hyx.
-    simpl in Hyx.
-    assert (H : In Trace (Union Trace (y d i) (x d i)) t).
-    { apply Union_introl; assumption. }
-    rewrite Hyx in H.
-    assumption.
-Qed.
-
-Lemma endo_leq_trans : forall (x y z : Endo), 
-    x <== y -> y <== z -> x <== z.
-Proof.
-  unfold leq, Endo_LeqOp; simpl.
-  intros x y z Hxy Hyz.
-  extensionality d.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - intros t Ht.
-    inversion Ht as [t' H1 | t' H2].
-    + pose proof (f_equal (fun f => f d i) Hxy) as Hxy'.
-      assert (Ht_y : In Trace (y d i) t).
-      {
-        rewrite <- Hxy'.
+  Lemma endo_leq_trans : forall (x y z : Endo), 
+      x <== y -> y <== z -> x <== z.
+  Proof.
+    unfold leq, Endo_LeqOp; simpl.
+    intros x y z Hxy Hyz.
+    extensionality d.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split.
+    - intros t Ht.
+      inversion Ht as [t' H1 | t' H2].
+      + pose proof (f_equal (fun f => f d i) Hxy) as Hxy'.
+        assert (Ht_y : In Trace (y d i) t).
+        {
+          rewrite <- Hxy'.
+          apply Union_introl.
+          assumption.
+        }
+        pose proof (f_equal (fun f => f d i) Hyz) as Hyz'.
+        rewrite <- Hyz'.
         apply Union_introl.
         assumption.
-      }
-      pose proof (f_equal (fun f => f d i) Hyz) as Hyz'.
-      rewrite <- Hyz'.
-      apply Union_introl.
+      + assumption.
+    - intros t Ht.
+      apply Union_intror.
       assumption.
-    + assumption.
-  - intros t Ht.
-    apply Union_intror.
+  Qed.
+
+  Global Instance Endo_PartiallyOrdered : PartiallyOrdered (Lo := Endo_LeqOp) := {
+    leq_refl := endo_leq_refl;
+    leq_antisym := endo_leq_antisym;
+    leq_trans := endo_leq_trans;
+  }.
+
+  Lemma endo_leq_plus_def : forall (x y : Endo), 
+      x <== y <-> x + y = y.
+  Proof.
+    intros x y.
+    split.
+    - intro H. exact H.
+    - intro H. exact H.
+  Qed.
+
+  Lemma endo_leq_pointwise_into : forall (a b : Endo),
+    (forall (x : Domain), a x <== b x) -> a <== b.
+  Proof.
+    intros a b H.
+    unfold leq, Endo_LeqOp.
+    extensionality d.
+    specialize (H d).
+    apply domain_leq_plus_def.
     assumption.
-Qed.
+  Qed.
 
-Instance Endo_PartiallyOrdered : PartiallyOrdered (Lo := Endo_LeqOp) := {
-  leq_refl := endo_leq_refl;
-  leq_antisym := endo_leq_antisym;
-  leq_trans := endo_leq_trans;
-}.
-
-Lemma endo_leq_plus_def : forall (x y : Endo), 
-    x <== y <-> x + y = y.
-Proof.
-  intros x y.
-  split.
-  - intro H. exact H.
-  - intro H. exact H.
-Qed.
-
-Lemma endo_leq_pointwise_into : forall (a b : Endo),
-  (forall (x : Domain), a x <== b x) -> a <== b.
-Proof.
-  intros a b H.
-  unfold leq, Endo_LeqOp.
-  extensionality d.
-  specialize (H d).
-  apply domain_leq_plus_def.
-  assumption.
-Qed.
-
-Lemma endo_leq_pointwise_elim : forall (a b : Endo),
-  forall (x : Domain), a <== b -> a x <== b x.
-Proof.
-  intros a b x H.
-  unfold leq, Endo_LeqOp in H.
-  apply domain_leq_plus_def.
-  assert (H1 : a x + b x = (a + b) x) by reflexivity. 
-  rewrite H1.
-  rewrite H.
-  reflexivity.
-Qed.
-
-Lemma endo_plus_neutral_left : forall (x : Endo), 
-    0 + x = x.
-Proof.
-  intros x.
-  extensionality d.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - intros t H. inversion H; [inversion H0 | assumption].
-  - intros t H. apply Union_intror; assumption.
-Qed.
-
-Lemma endo_plus_idem : forall (x : Endo), 
-    x + x = x.
-Proof.
-  intros x.
-  extensionality d.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - intros t H. inversion H; assumption.
-  - intros t H. apply Union_introl; assumption.
-Qed.
-
-Lemma endo_plus_assoc : forall (x y z : Endo), 
-    x + (y + z) = (x + y) + z.
-Proof.
-  intros x y z.
-  extensionality d.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - intros t H.
-    inversion H as [t' H1 | t' H1].
-    + apply Union_introl. apply Union_introl. assumption.
-    + inversion H1 as [t'' H2 | t'' H2].
-      * apply Union_introl. apply Union_intror. assumption.
-      * apply Union_intror. assumption.
-  - intros t H.
-    inversion H as [t' H1 | t' H1].
-    + inversion H1 as [t'' H2 | t'' H2].
-      * apply Union_introl. assumption.
-      * apply Union_intror. apply Union_introl. assumption.
-    + apply Union_intror. apply Union_intror. assumption.
-Qed.
-
-Lemma endo_plus_com : forall (x y : Endo), 
-    x + y = y + x.
-Proof.
-  intros x y.
-  extensionality d.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - intros t H.
-    inversion H; [apply Union_intror | apply Union_introl]; assumption.
-  - intros t H.
-    inversion H; [apply Union_intror | apply Union_introl]; assumption.
-Qed.
-
-Instance Endo_SemiLattice : SemiLattice (SLo := Endo_SemiLatticeOps) (Lo := Endo_LeqOp) := {
-    PO_SemiLattice := Endo_PartiallyOrdered;
-    leq_plus_def := endo_leq_plus_def;
-    plus_neutral_left := endo_plus_neutral_left;
-    plus_idem := endo_plus_idem;
-    plus_assoc := endo_plus_assoc;
-    plus_com := endo_plus_com
-}.
-
-Lemma endo_dot_ann_left : forall (x : Endo), 0 * x = 0.
-Proof.
-  intros x.
-  extensionality d.
-  extensionality i.
-  apply Extensionality_Ensembles.
-  split.
-  - intros t H.
-    inversion H.
-  - intros t H.
-    inversion H.
-Qed.
-
-Lemma endo_dot_distr_left : forall (x y z : Endo), 
-    (x + y) * z = x * z + y * z.
-Proof.
-  reflexivity.
-Qed.
-
-Lemma endo_dot_monotone_left : forall (z : Endo) (x y : Endo),
-    x <== y -> z * x <== z * y.
-Proof.
-  intros z x y Hleq.
-  apply functional_extensionality.
-  intro d.
-  extensionality i.
-  
-  assert (x_d_le_y_d : x d <== y d).
-  {
-    intro j.
-    pose proof (f_equal (fun f => f d j) Hleq) as Heq.
-    red; intros t Ht.
-    rewrite <- Heq.
-    apply Union_introl.
-    assumption.
-  }
-  
-  specialize (endo_monotone z (x d) (y d) x_d_le_y_d).
-  intro Hz_mono.
-  specialize (Hz_mono i).
-  
-  apply Extensionality_Ensembles.
-  split.
-  - intros t H.
-    inversion H as [t' H1 | t' H2].
-    + apply Hz_mono.
-      assumption.
-    + assumption.
-  - intros t H.
-    apply Union_intror.
-    assumption.
-Qed.
-
-Lemma endo_dot_monotone_right : forall x y z, x <== y -> x * z <== y * z.
-Proof.
-  intros x y z H.
-  unfold leq, Endo_LeqOp in H.
-  unfold leq, Endo_LeqOp.
-  rewrite <- endo_dot_distr_left.
-  rewrite H.
-  reflexivity.
-Qed.
-
-Lemma plus_leq_upper_bound : forall (a b c : Endo),
-  a <== c -> b <== c -> a + b <== c.
-Proof.
-  intros a b c Ha Hb.
-  apply leq_plus_def.
-  rewrite <- plus_assoc.
-  rewrite Hb.
-  rewrite Ha.
-  reflexivity.
-Qed.
-
-Lemma plus_is_lub_left: forall (a b c : Endo),
-  a + b <== c -> a <== c.
-Proof.
-  intros a b c H.
-  unfold leq, Endo_LeqOp in H.
-  unfold leq, Endo_LeqOp.
-  rewrite <- H.
-  rewrite 2 plus_assoc.
-  rewrite plus_idem.
-  reflexivity.
-Qed.
-
-Lemma plus_is_lub_right: forall (a b c : Endo),
-  a + b <== c -> b <== c.
-Proof.
-  intros a b c H. 
-  rewrite plus_com in H.
-  apply (plus_is_lub_left b a c H).
-Qed.
-
-Lemma endo_dot_distr_leq_right : forall (x y z : Endo),
-    z * x + z * y <== z * (x + y).
-Proof.
-  intros x y z.
-  
-  assert (Hx : x <== x + y).
-  {
-    apply leq_plus_def.
-    apply (eq_trans (plus_assoc x x y)).
-    rewrite plus_idem.
-    reflexivity. 
-  }
-  
-  assert (Hy : y <== x + y).
-  {
-    apply leq_plus_def.
-    apply (eq_trans (plus_assoc y x y)).
-    rewrite <- plus_com.
-    apply (eq_trans (plus_assoc y y x)).
-    rewrite plus_idem.
-    rewrite <- plus_com.
+  Lemma endo_leq_pointwise_elim : forall (a b : Endo),
+    forall (x : Domain), a <== b -> a x <== b x.
+  Proof.
+    intros a b x H.
+    unfold leq, Endo_LeqOp in H.
+    apply domain_leq_plus_def.
+    assert (H1 : a x + b x = (a + b) x) by reflexivity. 
+    rewrite H1.
+    rewrite H.
     reflexivity.
-  }
-  
-  assert (Hzx : z * x <== z * (x + y)).
-  { apply endo_dot_monotone_left. assumption. }
-  
-  assert (Hzy : z * y <== z * (x + y)).
-  { apply endo_dot_monotone_left. assumption. }
+  Qed.
 
-  apply plus_leq_upper_bound.
-  - exact Hzx.
-  - exact Hzy.
-Qed.
-
-Instance Endo_LeftHandedIdemSemiRing : LeftHandedIdemSemiRing (Mo := Endo_MonoidOps) (SLo := Endo_SemiLatticeOps) (Lo := Endo_LeqOp) := {
-    LHISR_Monoid := Endo_Monoid;
-    LHISR_SemiLattice := Endo_SemiLattice;
-    dot_ann_left := endo_dot_ann_left;
-    dot_distr_left := endo_dot_distr_left;
-    dot_distr_leq_right := endo_dot_distr_leq_right
-}.
-
-Lemma endo_dot_distr_right : forall (z x y : СontinuousEndo), 
-    z * (x + y) = z * x + z * y.
-Proof.
-  intros z x y.
-  extensionality d.
-  unfold dot, plus, Endo_MonoidOps, Endo_SemiLatticeOps; simpl.
-  unfold compose.
-  
-  assert (H: (fun i : string => Union Trace (x d i) (y d i)) = plus (x d) (y d)).
-  { apply functional_extensionality; intro i. reflexivity. }
-  
-  rewrite H.
-  rewrite endo_continuous_binary.
-  reflexivity.
-Qed.
-
-Lemma endo_preserves_zero : forall (a : СontinuousEndo), a zero = zero.
-Proof.
-  intro a.
-  rewrite <- domain_lub_empty.
-  rewrite endo_continuous with (X := Empty_set Domain) by assumption.
-  
-  assert (Im_empty : Im _ _ (Empty_set Domain) a = Empty_set Domain).
-  {
+  Lemma endo_plus_neutral_left : forall (x : Endo), 
+      0 + x = x.
+  Proof.
+    intros x.
+    extensionality d.
+    extensionality i.
     apply Extensionality_Ensembles.
     split.
-    - intros y Hy. inversion Hy. contradiction.
-    - intros y Hy. contradiction.
-  }
-  rewrite Im_empty.
-  rewrite domain_lub_empty.
-  reflexivity.
-Qed.
+    - intros t H. inversion H; [inversion H0 | assumption].
+    - intros t H. apply Union_intror; assumption.
+  Qed.
 
-Lemma endo_dot_ann_right : forall (x : СontinuousEndo), x * 0 = 0.
-Proof.
-  intros x.
-  unfold dot, zero, Endo_MonoidOps, Endo_SemiLatticeOps; simpl.
-  unfold compose.
-  apply functional_extensionality.
-  intro d.
-  rewrite endo_preserves_zero.
-  reflexivity.
-Qed.
+  Lemma endo_plus_idem : forall (x : Endo), 
+      x + x = x.
+  Proof.
+    intros x.
+    extensionality d.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split.
+    - intros t H. inversion H; assumption.
+    - intros t H. apply Union_introl; assumption.
+  Qed.
 
-Instance СontinuousEndo_IdemSemiRing : IdemSemiRing (Mo := Endo_MonoidOps) (SLo := Endo_SemiLatticeOps) (Lo := Endo_LeqOp) := {
-    ISR_LHISR := Endo_LeftHandedIdemSemiRing;
-    dot_ann_right := endo_dot_ann_right;
-    dot_distr_right := endo_dot_distr_right
-}. 
+  Lemma endo_plus_assoc : forall (x y z : Endo), 
+      x + (y + z) = (x + y) + z.
+  Proof.
+    intros x y z.
+    extensionality d.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split.
+    - intros t H.
+      inversion H as [t' H1 | t' H1].
+      + apply Union_introl. apply Union_introl. assumption.
+      + inversion H1 as [t'' H2 | t'' H2].
+        * apply Union_introl. apply Union_intror. assumption.
+        * apply Union_intror. assumption.
+    - intros t H.
+      inversion H as [t' H1 | t' H1].
+      + inversion H1 as [t'' H2 | t'' H2].
+        * apply Union_introl. assumption.
+        * apply Union_intror. apply Union_introl. assumption.
+      + apply Union_intror. apply Union_intror. assumption.
+  Qed.
 
-Definition Endo_sup (X : Ensemble Endo) : Endo :=
-  fun d i t => exists f, In _ X f /\ In _ (f d i) t.
+  Lemma endo_plus_com : forall (x y : Endo), 
+      x + y = y + x.
+  Proof.
+    intros x y.
+    extensionality d.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split.
+    - intros t H.
+      inversion H; [apply Union_intror | apply Union_introl]; assumption.
+    - intros t H.
+      inversion H; [apply Union_intror | apply Union_introl]; assumption.
+  Qed.
 
-Definition Endo_inf (X : Ensemble Endo) : Endo :=
-  fun d i t => forall f, In _ X f -> In _ (f d i) t.
+  Global Instance Endo_SemiLattice : SemiLattice (SLo := Endo_SemiLatticeOps) (Lo := Endo_LeqOp) := {
+      PO_SemiLattice := Endo_PartiallyOrdered;
+      leq_plus_def := endo_leq_plus_def;
+      plus_neutral_left := endo_plus_neutral_left;
+      plus_idem := endo_plus_idem;
+      plus_assoc := endo_plus_assoc;
+      plus_com := endo_plus_com
+  }.
 
-Lemma Endo_sup_is_lub : forall X, LUB X (Endo_sup X).
-Proof.
-  intro X.
-  constructor.
-  - intros f Hf_in_X.
+  Lemma endo_dot_ann_left : forall (x : Endo), 0 * x = 0.
+  Proof.
+    intros x.
+    extensionality d.
+    extensionality i.
+    apply Extensionality_Ensembles.
+    split.
+    - intros t H.
+      inversion H.
+    - intros t H.
+      inversion H.
+  Qed.
+
+  Lemma endo_dot_distr_left : forall (x y z : Endo), 
+      (x + y) * z = x * z + y * z.
+  Proof.
+    reflexivity.
+  Qed.
+
+  Lemma endo_dot_monotone_left : forall (z : Endo) (x y : Endo),
+      x <== y -> z * x <== z * y.
+  Proof.
+    intros z x y Hleq.
     apply functional_extensionality.
     intro d.
-    apply leq_plus_def.
-    intros i t Ht.
-    exists f.
-    split; assumption.
-  - intros g H_g_upper_bound.
-    apply functional_extensionality.
-    intro d.
-    apply leq_plus_def.
-    intros i t Ht.
-    destruct Ht as [f [Hf_in_X Ht_in_f]].
-    specialize (H_g_upper_bound f Hf_in_X).
-    apply (f_equal (fun h => h d)) in H_g_upper_bound.
-    apply domain_leq_plus_def in H_g_upper_bound.
-    specialize (H_g_upper_bound i).
-    apply H_g_upper_bound.
-    assumption.
-Qed.
-  
-Lemma Endo_inf_is_glb : forall X, GLB X (Endo_inf X).
-Proof.
-  intro X.
-  constructor.
-  - intros f Hf_in_X.
-    apply functional_extensionality.
-    intro d.
-    apply leq_plus_def.
-    intros i t Ht.
-    apply Ht.
-    assumption.
-  - intros g H_g_lower_bound.
-    apply functional_extensionality.
-    intro d.
-    apply leq_plus_def.
-    intros i t Ht f Hf_in_X.
-    specialize (H_g_lower_bound f Hf_in_X).
-    apply (f_equal (fun h => h d)) in H_g_lower_bound.
-    apply domain_leq_plus_def in H_g_lower_bound.
-    specialize (H_g_lower_bound i).
-    apply H_g_lower_bound.
-    assumption.
-Qed.
-
-Instance Endo_CompleteLattice : CompleteLattice (Lo := Endo_LeqOp) := {
-  PO_CompleteLattice := Endo_PartiallyOrdered;
-  sup := Endo_sup;
-  sup_is_lub := Endo_sup_is_lub;
-  inf := Endo_inf;
-  inf_is_glb := Endo_inf_is_glb;
-}.
-
-Definition star_operator (a : Endo) (d : Domain) : Endo :=
-  fun (x : Domain) => d + a x.
-
-Lemma star_operator_monotone (a : Endo) (d : Domain) : Monotone (star_operator a d).
-Proof.
-  unfold Monotone, star_operator.
-  intros x y Hleq.
-  apply domain_plus_monotone_left.
-  apply endo_monotone.
-  assumption.
-Qed.
-
-Instance Endo_StarOp : Star_Op Endo := {
-  star a := fun d => lfp (star_operator a d) (star_operator_monotone a d)
-}.
-
-Lemma Endo_star_fixed_point_right (a : Endo) (d : Domain) :
-  star_operator a d (a# d) = (a# d).
-Proof.
-  apply lfp_is_fixed_point.
-Qed.
-
-Lemma endo_star_make_right : forall (x : Endo),
-    1 + x * x# = x#.
-Proof.
-  intro x.
-  extensionality d.
-  apply Endo_star_fixed_point_right.
-Qed.
-
-Lemma endo_star_destruct_left : forall (a b : Endo),
-    a*b <== b -> a#*b <== b.
-Proof.
-  intros a b H.
-
-  assert (forall x, star_operator a (b x) (b x) <== (b x)).
-  {
-    intro x.
-    apply domain_plus_is_lub.
-    apply domain_leq_refl.
-    assert (H1 : (a * b) x <== b x). {
-      apply endo_leq_pointwise_elim.
+    extensionality i.
+    
+    assert (x_d_le_y_d : x d <== y d).
+    {
+      intro j.
+      pose proof (f_equal (fun f => f d j) Hleq) as Heq.
+      red; intros t Ht.
+      rewrite <- Heq.
+      apply Union_introl.
       assumption.
     }
-    assumption.
-  }
+    
+    specialize (endo_monotone z (x d) (y d) x_d_le_y_d).
+    intro Hz_mono.
+    specialize (Hz_mono i).
+    
+    apply Extensionality_Ensembles.
+    split.
+    - intros t H.
+      inversion H as [t' H1 | t' H2].
+      + apply Hz_mono.
+        assumption.
+      + assumption.
+    - intros t H.
+      apply Union_intror.
+      assumption.
+  Qed.
 
-  apply endo_leq_pointwise_into.
-  intro x.
-  specialize (H0 x).
-  apply (domain_leq_trans ((a # * b) x) (star_operator a (b x) (b x)) (b x)).
-  - apply inf_is_glb.
+  Lemma endo_dot_monotone_right : forall x y z, x <== y -> x * z <== y * z.
+  Proof.
+    intros x y z H.
+    unfold leq, Endo_LeqOp in H.
+    unfold leq, Endo_LeqOp.
+    rewrite <- endo_dot_distr_left.
+    rewrite H.
+    reflexivity.
+  Qed.
+
+  Lemma plus_leq_upper_bound : forall (a b c : Endo),
+    a <== c -> b <== c -> a + b <== c.
+  Proof.
+    intros a b c Ha Hb.
+    apply leq_plus_def.
+    rewrite <- plus_assoc.
+    rewrite Hb.
+    rewrite Ha.
+    reflexivity.
+  Qed.
+
+  Lemma plus_is_lub_left: forall (a b c : Endo),
+    a + b <== c -> a <== c.
+  Proof.
+    intros a b c H.
+    unfold leq, Endo_LeqOp in H.
+    unfold leq, Endo_LeqOp.
+    rewrite <- H.
+    rewrite 2 plus_assoc.
+    rewrite plus_idem.
+    reflexivity.
+  Qed.
+
+  Lemma plus_is_lub_right: forall (a b c : Endo),
+    a + b <== c -> b <== c.
+  Proof.
+    intros a b c H. 
+    rewrite plus_com in H.
+    apply (plus_is_lub_left b a c H).
+  Qed.
+
+  Lemma endo_dot_distr_leq_right : forall (x y z : Endo),
+      z * x + z * y <== z * (x + y).
+  Proof.
+    intros x y z.
+    
+    assert (Hx : x <== x + y).
+    {
+      apply leq_plus_def.
+      apply (eq_trans (plus_assoc x x y)).
+      rewrite plus_idem.
+      reflexivity. 
+    }
+    
+    assert (Hy : y <== x + y).
+    {
+      apply leq_plus_def.
+      apply (eq_trans (plus_assoc y x y)).
+      rewrite <- plus_com.
+      apply (eq_trans (plus_assoc y y x)).
+      rewrite plus_idem.
+      rewrite <- plus_com.
+      reflexivity.
+    }
+    
+    assert (Hzx : z * x <== z * (x + y)).
+    { apply endo_dot_monotone_left. assumption. }
+    
+    assert (Hzy : z * y <== z * (x + y)).
+    { apply endo_dot_monotone_left. assumption. }
+
+    apply plus_leq_upper_bound.
+    - exact Hzx.
+    - exact Hzy.
+  Qed.
+
+  Global Instance Endo_LeftHandedIdemSemiRing : LeftHandedIdemSemiRing (Mo := Endo_MonoidOps) (SLo := Endo_SemiLatticeOps) (Lo := Endo_LeqOp) := {
+      LHISR_Monoid := Endo_Monoid;
+      LHISR_SemiLattice := Endo_SemiLattice;
+      dot_ann_left := endo_dot_ann_left;
+      dot_distr_left := endo_dot_distr_left;
+      dot_distr_leq_right := endo_dot_distr_leq_right
+  }.
+
+  Lemma endo_dot_distr_right : forall (z x y : СontinuousEndo), 
+      z * (x + y) = z * x + z * y.
+  Proof.
+    intros z x y.
+    extensionality d.
+    unfold dot, plus, Endo_MonoidOps, Endo_SemiLatticeOps; simpl.
+    unfold compose.
+    
+    assert (H: (fun i => Union Trace (x d i) (y d i)) = plus (x d) (y d)).
+    { apply functional_extensionality; intro i. reflexivity. }
+    
+    rewrite H.
+    rewrite endo_continuous_binary.
+    reflexivity.
+  Qed.
+
+  Lemma endo_preserves_zero : forall (a : СontinuousEndo), a zero = zero.
+  Proof.
+    intro a.
+    rewrite <- domain_lub_empty.
+    rewrite endo_continuous with (X := Empty_set Domain) by assumption.
+    
+    assert (Im_empty : Im _ _ (Empty_set Domain) a = Empty_set Domain).
+    {
+      apply Extensionality_Ensembles.
+      split.
+      - intros y Hy. inversion Hy. contradiction.
+      - intros y Hy. contradiction.
+    }
+    rewrite Im_empty.
+    rewrite domain_lub_empty.
+    reflexivity.
+  Qed.
+
+  Lemma endo_dot_ann_right : forall (x : СontinuousEndo), x * 0 = 0.
+  Proof.
+    intros x.
+    unfold dot, zero, Endo_MonoidOps, Endo_SemiLatticeOps; simpl.
+    unfold compose.
+    apply functional_extensionality.
+    intro d.
+    rewrite endo_preserves_zero.
+    reflexivity.
+  Qed.
+
+  Global Instance СontinuousEndo_IdemSemiRing : IdemSemiRing (Mo := Endo_MonoidOps) (SLo := Endo_SemiLatticeOps) (Lo := Endo_LeqOp) := {
+      ISR_LHISR := Endo_LeftHandedIdemSemiRing;
+      dot_ann_right := endo_dot_ann_right;
+      dot_distr_right := endo_dot_distr_right
+  }. 
+
+  Definition Endo_sup (X : Ensemble Endo) : Endo :=
+    fun d i t => exists f, In _ X f /\ In _ (f d i) t.
+
+  Definition Endo_inf (X : Ensemble Endo) : Endo :=
+    fun d i t => forall f, In _ X f -> In _ (f d i) t.
+
+  Lemma Endo_sup_is_lub : forall X, LUB X (Endo_sup X).
+  Proof.
+    intro X.
+    constructor.
+    - intros f Hf_in_X.
+      apply functional_extensionality.
+      intro d.
+      apply leq_plus_def.
+      intros i t Ht.
+      exists f.
+      split; assumption.
+    - intros g H_g_upper_bound.
+      apply functional_extensionality.
+      intro d.
+      apply leq_plus_def.
+      intros i t Ht.
+      destruct Ht as [f [Hf_in_X Ht_in_f]].
+      specialize (H_g_upper_bound f Hf_in_X).
+      apply (f_equal (fun h => h d)) in H_g_upper_bound.
+      apply domain_leq_plus_def in H_g_upper_bound.
+      specialize (H_g_upper_bound i).
+      apply H_g_upper_bound.
+      assumption.
+  Qed.
+    
+  Lemma Endo_inf_is_glb : forall X, GLB X (Endo_inf X).
+  Proof.
+    intro X.
+    constructor.
+    - intros f Hf_in_X.
+      apply functional_extensionality.
+      intro d.
+      apply leq_plus_def.
+      intros i t Ht.
+      apply Ht.
+      assumption.
+    - intros g H_g_lower_bound.
+      apply functional_extensionality.
+      intro d.
+      apply leq_plus_def.
+      intros i t Ht f Hf_in_X.
+      specialize (H_g_lower_bound f Hf_in_X).
+      apply (f_equal (fun h => h d)) in H_g_lower_bound.
+      apply domain_leq_plus_def in H_g_lower_bound.
+      specialize (H_g_lower_bound i).
+      apply H_g_lower_bound.
+      assumption.
+  Qed.
+
+  Global Instance Endo_CompleteLattice : CompleteLattice (Lo := Endo_LeqOp) := {
+    PO_CompleteLattice := Endo_PartiallyOrdered;
+    sup := Endo_sup;
+    sup_is_lub := Endo_sup_is_lub;
+    inf := Endo_inf;
+    inf_is_glb := Endo_inf_is_glb;
+  }.
+
+  Definition star_operator (a : Endo) (d : Domain) : Endo :=
+    fun (x : Domain) => d + a x.
+
+  Lemma star_operator_monotone (a : Endo) (d : Domain) : Monotone (star_operator a d).
+  Proof.
+    unfold Monotone, star_operator.
+    intros x y Hleq.
+    apply domain_plus_monotone_left.
     apply endo_monotone.
     assumption.
-  - assumption.
-Qed.
+  Qed.
 
-Instance Endo_LeftHandedKleneeAlgebra : LeftHandedKleneeAlgebra (Mo := Endo_MonoidOps) (SLo := Endo_SemiLatticeOps) (So := Endo_StarOp) (Lo := Endo_LeqOp) := {
-  LHKA_LHISR := Endo_LeftHandedIdemSemiRing;
-  star_make_right := endo_star_make_right;
-  star_destruct_left := endo_star_destruct_left
-}.
+  Global Instance Endo_StarOp : Star_Op Endo := {
+    star a := fun d => lfp (star_operator a d) (star_operator_monotone a d)
+  }.
 
-Lemma Endo_star_fixed_point_left (a : СontinuousEndo) (d : Domain) :
-  star_operator (a#) d (a d) = (a# d).
-Proof.
-  apply leq_antisym.
+  Lemma Endo_star_fixed_point_right (a : Endo) (d : Domain) :
+    star_operator a d (a# d) = (a# d).
+  Proof.
+    apply lfp_is_fixed_point.
+  Qed.
 
-  - apply inf_is_glb.
-    intros x H.
-  
-    set (P := fun x : Domain => a d + a x <== x).
-    apply (domain_leq_trans (d + inf P) (d + a x) x).
-    + apply domain_plus_monotone_left.
-      destruct (inf_is_glb P) as [H_lower _].
-      apply H_lower.
-      unfold In.
-      assert (a (d + (a x)) = a d + a (a x)). 
-      {
-        apply endo_continuous_binary.
+  Lemma endo_star_make_right : forall (x : Endo),
+      1 + x * x# = x#.
+  Proof.
+    intro x.
+    extensionality d.
+    apply Endo_star_fixed_point_right.
+  Qed.
+
+  Lemma endo_star_destruct_left : forall (a b : Endo),
+      a*b <== b -> a#*b <== b.
+  Proof.
+    intros a b H.
+
+    assert (forall x, star_operator a (b x) (b x) <== (b x)).
+    {
+      intro x.
+      apply domain_plus_is_lub.
+      apply domain_leq_refl.
+      assert (H1 : (a * b) x <== b x). {
+        apply endo_leq_pointwise_elim.
+        assumption.
       }
-      unfold P.
-      rewrite <- H0.
+      assumption.
+    }
+
+    apply endo_leq_pointwise_into.
+    intro x.
+    specialize (H0 x).
+    apply (domain_leq_trans ((a # * b) x) (star_operator a (b x) (b x)) (b x)).
+    - apply inf_is_glb.
       apply endo_monotone.
       assumption.
-    + assumption.
+    - assumption.
+  Qed.
 
-  - apply inf_is_glb.
-    unfold star_operator.
-    apply endo_monotone.
+  Global Instance Endo_LeftHandedKleneeAlgebra : LeftHandedKleneeAlgebra (Mo := Endo_MonoidOps) (SLo := Endo_SemiLatticeOps) (So := Endo_StarOp) (Lo := Endo_LeqOp) := {
+    LHKA_LHISR := Endo_LeftHandedIdemSemiRing;
+    star_make_right := endo_star_make_right;
+    star_destruct_left := endo_star_destruct_left
+  }.
 
-    set (P := fun x : Domain => a d + a x <== x).
-    intros s t Ht x Hx_P.
-  
-    destruct (inf_is_glb P) as [H_lower _].
+  Lemma Endo_star_fixed_point_left (a : СontinuousEndo) (d : Domain) :
+    star_operator (a#) d (a d) = (a# d).
+  Proof.
+    apply leq_antisym.
 
-    assert (H_sum : d + inf P <== d + x).
-    { apply domain_plus_monotone_left. apply H_lower. exact Hx_P. }
+    - apply inf_is_glb.
+      intros x H.
+    
+      set (P := fun x : Domain => a d + a x <== x).
+      apply (domain_leq_trans (d + inf P) (d + a x) x).
+      + apply domain_plus_monotone_left.
+        destruct (inf_is_glb P) as [H_lower _].
+        apply H_lower.
+        unfold In.
+        assert (a (d + (a x)) = a d + a (a x)). 
+        {
+          apply endo_continuous_binary.
+        }
+        unfold P.
+        rewrite <- H0.
+        apply endo_monotone.
+        assumption.
+      + assumption.
 
-    assert (H_a_mono : a (d + inf P) <== a (d + x)).
-    { apply endo_monotone. exact H_sum. }
+    - apply inf_is_glb.
+      unfold star_operator.
+      apply endo_monotone.
 
-    assert (H : forall x, a (d + x) = a d + a x).
-    { intro. apply endo_continuous_binary. }
+      set (P := fun x : Domain => a d + a x <== x).
+      intros s t Ht x Hx_P.
+    
+      destruct (inf_is_glb P) as [H_lower _].
 
-    rewrite H in H_a_mono.
+      assert (H_sum : d + inf P <== d + x).
+      { apply domain_plus_monotone_left. apply H_lower. exact Hx_P. }
 
-    assert (H0 : a (d + inf P) <== x).
-    { apply (domain_leq_trans (a (d + inf P)) (a d + a x) x).
-      - rewrite <- H. apply endo_monotone. assumption.
-      - exact Hx_P. }
+      assert (H_a_mono : a (d + inf P) <== a (d + x)).
+      { apply endo_monotone. exact H_sum. }
 
-    specialize (H0 s).
+      assert (H : forall x, a (d + x) = a d + a x).
+      { intro. apply endo_continuous_binary. }
 
-    apply H0.
-    assumption.
-Qed.
+      rewrite H in H_a_mono.
 
-Lemma endo_star_make_left : forall (x : СontinuousEndo),
-    1 + x# * x = x#.
-Proof.
-  intro x.
-  extensionality d.
-  apply Endo_star_fixed_point_left.
-Qed.
+      assert (H0 : a (d + inf P) <== x).
+      { apply (domain_leq_trans (a (d + inf P)) (a d + a x) x).
+        - rewrite <- H. apply endo_monotone. assumption.
+        - exact Hx_P. }
 
-Lemma endo_plus_is_lub : forall x y z,
-  x <== z -> y <== z -> x + y <== z.
-Proof.
-  intros x y z H1 H2.
-  apply leq_plus_def.
-  rewrite leq_plus_def in H1.
-  rewrite leq_plus_def in H2.
-  rewrite <- plus_assoc.
-  rewrite H2.
-  rewrite H1.
-  reflexivity.
-Qed.
+      specialize (H0 s).
 
-Fixpoint pow (a : Endo) (n : nat) : Endo :=
-  match n with
-    | O => 1
-    | S n' => a * pow a n'
-  end.
-
-Axiom star_sup_pow : forall (a : СontinuousEndo), 
-  a# = sup (Im _ _ (Full_set nat) (pow a)).
-
-Axiom endo_dot_sup_left : forall (b : СontinuousEndo) (X : Ensemble Endo),
-    b * (sup X) = sup (Im _ _ X (fun x => b * x)).
-
-Lemma endo_star_destruct_right : forall (a b : СontinuousEndo),
-    b * a <== b -> b * a# <== b.
-Proof.
-  intros a b Hba.  
-  rewrite star_sup_pow.
-
-  set (P := fun (f : Endo) => b * f <== b).
-  assert (P_sup_chain : forall (g : nat -> Endo),
-      (forall n, P (g n)) -> P (sup (Im nat Endo (Full_set nat) g))).
-  {
-    intros g H.
-    unfold P.
-    rewrite endo_dot_sup_left.
-
-    apply functional_extensionality.
-    intro d.
-    apply leq_plus_def.
-    intros i t Ht.
-    destruct Ht as [h [Hh_in_Im Ht_in_h]].
-    destruct Hh_in_Im as [f Hf_in_Im Hh_eq].
-    destruct Hf_in_Im as [n _ Hf_eq].
-    subst Hf_eq Hh_eq.
-  
-    specialize (H n).
-  
-    assert (H_sub : Included Trace ((b * g n) d i) (b d i)).
-    {
-      intros x Hx.
-      assert (H_union : In Trace ((b * g n + b) d i) x).
-      {
-        apply Union_introl.
-        exact Hx.
-      }
-      assert (Hin: In Trace (b d i) x).
-      {
-        rewrite <- H.
-        exact H_union.
-      }
+      apply H0.
       assumption.
-    }
-    
-    apply H_sub.
-    exact Ht_in_h.
-  }
+  Qed.
 
-  apply P_sup_chain.
+  Lemma endo_star_make_left : forall (x : СontinuousEndo),
+      1 + x# * x = x#.
+  Proof.
+    intro x.
+    extensionality d.
+    apply Endo_star_fixed_point_left.
+  Qed.
 
-  induction n.
-  - unfold P, pow.
-    rewrite dot_neutral_right. 
-    apply leq_refl.
-  - assert (P_closed : forall f, P f -> P (a * f)).
+  Lemma endo_plus_is_lub : forall x y z,
+    x <== z -> y <== z -> x + y <== z.
+  Proof.
+    intros x y z H1 H2.
+    apply leq_plus_def.
+    rewrite leq_plus_def in H1.
+    rewrite leq_plus_def in H2.
+    rewrite <- plus_assoc.
+    rewrite H2.
+    rewrite H1.
+    reflexivity.
+  Qed.
+
+  Fixpoint pow (a : Endo) (n : nat) : Endo :=
+    match n with
+      | O => 1
+      | S n' => a * pow a n'
+    end.
+
+  Axiom star_sup_pow : forall (a : СontinuousEndo), 
+    a# = sup (Im _ _ (Full_set nat) (pow a)).
+
+    (* TODO: prove *)
+  Axiom endo_dot_sup_left : forall (b : СontinuousEndo) (X : Ensemble Endo),
+      b * (sup X) = sup (Im _ _ X (fun x => b * x)).
+
+  Lemma endo_star_destruct_right : forall (a b : СontinuousEndo),
+      b * a <== b -> b * a# <== b.
+  Proof.
+    intros a b Hba.  
+    rewrite star_sup_pow.
+
+    set (P := fun (f : Endo) => b * f <== b).
+    assert (P_sup_chain : forall (g : nat -> Endo),
+        (forall n, P (g n)) -> P (sup (Im nat Endo (Full_set nat) g))).
     {
-      intros f Hf.
+      intros g H.
       unfold P.
-      rewrite dot_assoc.
-      apply (leq_trans ((b * a) * f) (b * f) b).
-      - apply endo_dot_monotone_right. 
-        exact Hba.
-      - exact Hf.
-    }
-    apply P_closed. 
-    assumption.
-Qed.
+      rewrite endo_dot_sup_left.
+
+      apply functional_extensionality.
+      intro d.
+      apply leq_plus_def.
+      intros i t Ht.
+      destruct Ht as [h [Hh_in_Im Ht_in_h]].
+      destruct Hh_in_Im as [f Hf_in_Im Hh_eq].
+      destruct Hf_in_Im as [n _ Hf_eq].
+      subst Hf_eq Hh_eq.
     
-Instance СontinuousEndo_KleeneAlgebra : KleeneAlgebra (Mo := Endo_MonoidOps) (SLo := Endo_SemiLatticeOps) (So := Endo_StarOp) (Lo := Endo_LeqOp) := {
-  KA_LHKA := Endo_LeftHandedKleneeAlgebra;
-  KA_ISR := СontinuousEndo_IdemSemiRing;
-  star_make_left := endo_star_make_left;
-  star_destruct_right := endo_star_destruct_right
-}.
+      specialize (H n).
+    
+      assert (H_sub : Included Trace ((b * g n) d i) (b d i)).
+      {
+        intros x Hx.
+        assert (H_union : In Trace ((b * g n + b) d i) x).
+        {
+          apply Union_introl.
+          exact Hx.
+        }
+        assert (Hin: In Trace (b d i) x).
+        {
+          rewrite <- H.
+          exact H_union.
+        }
+        assumption.
+      }
+      
+      apply H_sub.
+      exact Ht_in_h.
+    }
+
+    apply P_sup_chain.
+
+    induction n.
+    - unfold P, pow.
+      rewrite dot_neutral_right. 
+      apply leq_refl.
+    - assert (P_closed : forall f, P f -> P (a * f)).
+      {
+        intros f Hf.
+        unfold P.
+        rewrite dot_assoc.
+        apply (leq_trans ((b * a) * f) (b * f) b).
+        - apply endo_dot_monotone_right. 
+          exact Hba.
+        - exact Hf.
+      }
+      apply P_closed. 
+      assumption.
+  Qed.
+
+  Global Instance СontinuousEndo_KleeneAlgebra : KleeneAlgebra (Mo := Endo_MonoidOps) (SLo := Endo_SemiLatticeOps) (So := Endo_StarOp) (Lo := Endo_LeqOp) := {
+    KA_LHKA := Endo_LeftHandedKleneeAlgebra;
+    KA_ISR := СontinuousEndo_IdemSemiRing;
+    star_make_left := endo_star_make_left;
+    star_destruct_right := endo_star_destruct_right
+  }.
+
+End Endo.

--- a/src/Endo.v
+++ b/src/Endo.v
@@ -4,7 +4,7 @@ From Coq Require Import Sets.Powerset Sets.Image.
 From Coq Require Import Logic.FunctionalExtensionality.
 
 Section Endo.
-  Context `{params : TMParams}.
+  Context `{tm : TM}.
 
   Definition Endo := Domain -> Domain.
 

--- a/src/Endo.v
+++ b/src/Endo.v
@@ -1,690 +1,696 @@
-From klenee_complexity Require Import Algebraic_Structures Domain Conf LFP NEList Image_Facts.
-From Coq Require Import Program.Basics Strings.String.
+From klenee_complexity Require Import Algebraic_Structures Domain TM LFP NEList Image_Facts.
+From Coq Require Import Program.Basics.
 From Coq Require Import Sets.Powerset Sets.Image.
 From Coq Require Import Logic.FunctionalExtensionality.
 From Coq Require Import Logic.ProofIrrelevance.
 
-Definition Endo := Domain -> Domain.
+Section Endo.
+  Context `{tm : TM}.
 
-Instance Endo_MonoidOps : Monoid_Ops Endo := {
-    one := id;
-    dot := compose;
-}.
 
-Instance Endo_Monoid : Monoid (Mo := Endo_MonoidOps) := {
-    dot_assoc := fun x y z => eq_refl;
-    dot_neutral_left := fun x => eq_refl;
-    dot_neutral_right := fun x => eq_refl;
-}.
+  Definition Endo := Domain -> Domain.
 
-Instance Endo_SemiLatticeOps : SemiLattice_Ops Endo := {
-  zero := fun _ => zero;
-  plus a b := fun d => a d + b d;
-}.
+  Global Instance Endo_MonoidOps : Monoid_Ops Endo := {
+      one := id;
+      dot := compose;
+  }.
 
-Instance Endo_LeqOp : Leq_Op Endo := {
-    leq a b := a + b = b
-}.
+  Global Instance Endo_Monoid : Monoid (Mo := Endo_MonoidOps) := {
+      dot_assoc := fun x y z => eq_refl;
+      dot_neutral_left := fun x => eq_refl;
+      dot_neutral_right := fun x => eq_refl;
+  }.
 
-Lemma endo_leq_pointwise_into : forall (a b : Endo),
-  (forall (x : Domain), a x <== b x) -> a <== b.
-Proof.
-  intros a b H.
-  unfold leq, Endo_LeqOp.
-  extensionality d.
-  apply domain_leq_plus_def, H.
-Qed.
+  Global Instance Endo_SemiLatticeOps : SemiLattice_Ops Endo := {
+    zero := fun _ => zero;
+    plus a b := fun d => a d + b d;
+  }.
 
-Lemma endo_leq_pointwise_elim : forall (a b : Endo),
-  forall (x : Domain), a <== b -> a x <== b x.
-Proof.
-  intros a b x H.
-  apply domain_leq_plus_def.
-  exact (f_equal (fun f => f x) H).
-Qed.
+  Global Instance Endo_LeqOp : Leq_Op Endo := {
+      leq a b := a + b = b
+  }.
 
-Lemma endo_leq_refl : forall (a : Endo), a <== a.
-Proof.
-  intro a.
-  apply endo_leq_pointwise_into; intro; apply domain_leq_refl.
-Qed.
+  Lemma endo_leq_pointwise_into : forall (a b : Endo),
+    (forall (x : Domain), a x <== b x) -> a <== b.
+  Proof.
+    intros a b H.
+    unfold leq, Endo_LeqOp.
+    extensionality d.
+    apply domain_leq_plus_def, H.
+  Qed.
 
-Lemma endo_leq_antisym : forall (x y : Endo),
-    x <== y -> y <== x -> x = y.
-Proof.
-  intros x y Hxy Hyx.
-  extensionality d.
-  apply domain_leq_antisym; apply endo_leq_pointwise_elim; assumption.
-Qed.
+  Lemma endo_leq_pointwise_elim : forall (a b : Endo),
+    forall (x : Domain), a <== b -> a x <== b x.
+  Proof.
+    intros a b x H.
+    apply domain_leq_plus_def.
+    exact (f_equal (fun f => f x) H).
+  Qed.
 
-Lemma endo_leq_trans : forall (x y z : Endo),
-    x <== y -> y <== z -> x <== z.
-Proof.
-  intros x y z Hxy Hyz.
-  apply endo_leq_pointwise_into; intro d.
-  apply (domain_leq_trans (x d) (y d) (z d));
-    apply endo_leq_pointwise_elim; assumption.
-Qed.
+  Lemma endo_leq_refl : forall (a : Endo), a <== a.
+  Proof.
+    intro a.
+    apply endo_leq_pointwise_into; intro; apply domain_leq_refl.
+  Qed.
 
-Instance Endo_PartiallyOrdered : PartiallyOrdered (Lo := Endo_LeqOp) := {
-  leq_refl := endo_leq_refl;
-  leq_antisym := endo_leq_antisym;
-  leq_trans := endo_leq_trans;
-}.
+  Lemma endo_leq_antisym : forall (x y : Endo),
+      x <== y -> y <== x -> x = y.
+  Proof.
+    intros x y Hxy Hyx.
+    extensionality d.
+    apply domain_leq_antisym; apply endo_leq_pointwise_elim; assumption.
+  Qed.
 
-Lemma endo_leq_plus_def : forall (x y : Endo),
-    x <== y <-> x + y = y.
-Proof. intros x y; split; intro H; exact H. Qed.
+  Lemma endo_leq_trans : forall (x y z : Endo),
+      x <== y -> y <== z -> x <== z.
+  Proof.
+    intros x y z Hxy Hyz.
+    apply endo_leq_pointwise_into; intro d.
+    apply (domain_leq_trans (x d) (y d) (z d));
+      apply endo_leq_pointwise_elim; assumption.
+  Qed.
 
-Lemma endo_plus_neutral_left : forall (x : Endo),
-    0 + x = x.
-Proof. intro x; extensionality d; apply domain_plus_neutral_left. Qed.
+  Global Instance Endo_PartiallyOrdered : PartiallyOrdered (Lo := Endo_LeqOp) := {
+    leq_refl := endo_leq_refl;
+    leq_antisym := endo_leq_antisym;
+    leq_trans := endo_leq_trans;
+  }.
 
-Lemma endo_plus_idem : forall (x : Endo),
-    x + x = x.
-Proof. intro x; extensionality d; apply domain_plus_idem. Qed.
+  Lemma endo_leq_plus_def : forall (x y : Endo),
+      x <== y <-> x + y = y.
+  Proof. intros x y; split; intro H; exact H. Qed.
 
-Lemma endo_plus_assoc : forall (x y z : Endo),
-    x + (y + z) = (x + y) + z.
-Proof. intros x y z; extensionality d; apply domain_plus_assoc. Qed.
+  Lemma endo_plus_neutral_left : forall (x : Endo),
+      0 + x = x.
+  Proof. intro x; extensionality d; apply domain_plus_neutral_left. Qed.
 
-Lemma endo_plus_com : forall (x y : Endo),
-    x + y = y + x.
-Proof. intros x y; extensionality d; apply domain_plus_com. Qed.
+  Lemma endo_plus_idem : forall (x : Endo),
+      x + x = x.
+  Proof. intro x; extensionality d; apply domain_plus_idem. Qed.
 
-Instance Endo_SemiLattice : SemiLattice (SLo := Endo_SemiLatticeOps) (Lo := Endo_LeqOp) := {
-    PO_SemiLattice := Endo_PartiallyOrdered;
-    leq_plus_def := endo_leq_plus_def;
-    plus_neutral_left := endo_plus_neutral_left;
-    plus_idem := endo_plus_idem;
-    plus_assoc := endo_plus_assoc;
-    plus_com := endo_plus_com
-}.
+  Lemma endo_plus_assoc : forall (x y z : Endo),
+      x + (y + z) = (x + y) + z.
+  Proof. intros x y z; extensionality d; apply domain_plus_assoc. Qed.
 
-Lemma endo_plus_is_lub : forall (a b c : Endo),
-  a <== c -> b <== c -> a + b <== c.
-Proof.
-  intros a b c Ha Hb.
-  apply leq_plus_def.
-  now rewrite <- plus_assoc, Hb, Ha.
-Qed.
+  Lemma endo_plus_com : forall (x y : Endo),
+      x + y = y + x.
+  Proof. intros x y; extensionality d; apply domain_plus_com. Qed.
 
-Lemma endo_leq_plus_left : forall (x y : Endo), x <== x + y.
-Proof.
-  intros x y; apply leq_plus_def.
-  now rewrite plus_assoc, plus_idem.
-Qed.
+  Global Instance Endo_SemiLattice : SemiLattice (SLo := Endo_SemiLatticeOps) (Lo := Endo_LeqOp) := {
+      PO_SemiLattice := Endo_PartiallyOrdered;
+      leq_plus_def := endo_leq_plus_def;
+      plus_neutral_left := endo_plus_neutral_left;
+      plus_idem := endo_plus_idem;
+      plus_assoc := endo_plus_assoc;
+      plus_com := endo_plus_com
+  }.
 
-Lemma endo_leq_plus_right : forall (x y : Endo), y <== x + y.
-Proof.
-  intros x y; apply leq_plus_def.
-  now rewrite (plus_com x y), plus_assoc, plus_idem.
-Qed.
+  Lemma endo_plus_is_lub : forall (a b c : Endo),
+    a <== c -> b <== c -> a + b <== c.
+  Proof.
+    intros a b c Ha Hb.
+    apply leq_plus_def.
+    now rewrite <- plus_assoc, Hb, Ha.
+  Qed.
 
-Lemma endo_dot_distr_left : forall (x y z : Endo),
-    (x + y) * z = x * z + y * z.
-Proof. reflexivity. Qed.
+  Lemma endo_leq_plus_left : forall (x y : Endo), x <== x + y.
+  Proof.
+    intros x y; apply leq_plus_def.
+    now rewrite plus_assoc, plus_idem.
+  Qed.
 
-Definition Endo_sup (X : Ensemble Endo) : Endo :=
-  fun d i t => exists f, In _ X f /\ In _ (f d i) t.
+  Lemma endo_leq_plus_right : forall (x y : Endo), y <== x + y.
+  Proof.
+    intros x y; apply leq_plus_def.
+    now rewrite (plus_com x y), plus_assoc, plus_idem.
+  Qed.
 
-Definition Endo_inf (X : Ensemble Endo) : Endo :=
-  fun d i t => forall f, In _ X f -> In _ (f d i) t.
+  Lemma endo_dot_distr_left : forall (x y z : Endo),
+      (x + y) * z = x * z + y * z.
+  Proof. reflexivity. Qed.
 
-Lemma Endo_sup_is_lub : forall X, LUB X (Endo_sup X).
-Proof.
-  intro X; split.
-  - intros f Hf.
-    apply endo_leq_pointwise_into; intros d i t Ht.
-    exists f; split; assumption.
-  - intros g Hg.
-    apply endo_leq_pointwise_into; intros d i t [f [Hf Ht]].
-    exact (endo_leq_pointwise_elim f g d (Hg f Hf) i t Ht).
-Qed.
+  Definition Endo_sup (X : Ensemble Endo) : Endo :=
+    fun d i t => exists f, In _ X f /\ In _ (f d i) t.
 
-Lemma Endo_sup_pointwise : forall (X : Ensemble Endo) (d : Domain),
-    Endo_sup X d = domain_lub (Im _ _ X (fun f => f d)).
-Proof.
-  intros X d.
-  extensionality i.
-  apply Extensionality_Ensembles; split; intros t Ht.
-  - destruct Ht as [f [Hf Ht]].
-    exists (f d); split; [ exact (Im_intro _ _ X (fun f => f d) f Hf _ eq_refl) | exact Ht ].
-  - destruct Ht as [g [Hg Ht]].
-    destruct Hg as [f Hf g Hgeq]; subst.
-    exists f; split; assumption.
-Qed.
+  Definition Endo_inf (X : Ensemble Endo) : Endo :=
+    fun d i t => forall f, In _ X f -> In _ (f d i) t.
 
-Lemma Endo_inf_is_glb : forall X, GLB X (Endo_inf X).
-Proof.
-  intro X; split.
-  - intros f Hf.
-    apply endo_leq_pointwise_into; intros d i t Ht.
-    exact (Ht f Hf).
-  - intros g Hg.
-    apply endo_leq_pointwise_into; intros d i t Ht f Hf.
-    exact (endo_leq_pointwise_elim g f d (Hg f Hf) i t Ht).
-Qed.
+  Lemma Endo_sup_is_lub : forall X, LUB X (Endo_sup X).
+  Proof.
+    intro X; split.
+    - intros f Hf.
+      apply endo_leq_pointwise_into; intros d i t Ht.
+      exists f; split; assumption.
+    - intros g Hg.
+      apply endo_leq_pointwise_into; intros d i t [f [Hf Ht]].
+      exact (endo_leq_pointwise_elim f g d (Hg f Hf) i t Ht).
+  Qed.
 
-Instance Endo_CompleteLattice : CompleteLattice (Lo := Endo_LeqOp) := {
-  PO_CompleteLattice := Endo_PartiallyOrdered;
-  sup := Endo_sup;
-  sup_is_lub := Endo_sup_is_lub;
-  inf := Endo_inf;
-  inf_is_glb := Endo_inf_is_glb;
-}.
+  Lemma Endo_sup_pointwise : forall (X : Ensemble Endo) (d : Domain),
+      Endo_sup X d = domain_lub (Im _ _ X (fun f => f d)).
+  Proof.
+    intros X d.
+    extensionality i.
+    apply Extensionality_Ensembles; split; intros t Ht.
+    - destruct Ht as [f [Hf Ht]].
+      exists (f d); split; [ exact (Im_intro _ _ X (fun f => f d) f Hf _ eq_refl) | exact Ht ].
+    - destruct Ht as [g [Hg Ht]].
+      destruct Hg as [f Hf g Hgeq]; subst.
+      exists f; split; assumption.
+  Qed.
 
-Definition star_operator (a : Endo) (d : Domain) : Endo :=
-  fun (x : Domain) => d + a x.
+  Lemma Endo_inf_is_glb : forall X, GLB X (Endo_inf X).
+  Proof.
+    intro X; split.
+    - intros f Hf.
+      apply endo_leq_pointwise_into; intros d i t Ht.
+      exact (Ht f Hf).
+    - intros g Hg.
+      apply endo_leq_pointwise_into; intros d i t Ht f Hf.
+      exact (endo_leq_pointwise_elim g f d (Hg f Hf) i t Ht).
+  Qed.
 
-Lemma star_operator_monotone (a : Endo) (d : Domain) (Hm : Monotone a) :
-  Monotone (star_operator a d).
-Proof.
-  unfold Monotone, star_operator.
-  intros x y Hleq.
-  apply domain_plus_monotone_left, Hm, Hleq.
-Qed.
+  Global Instance Endo_CompleteLattice : CompleteLattice (Lo := Endo_LeqOp) := {
+    PO_CompleteLattice := Endo_PartiallyOrdered;
+    sup := Endo_sup;
+    sup_is_lub := Endo_sup_is_lub;
+    inf := Endo_inf;
+    inf_is_glb := Endo_inf_is_glb;
+  }.
 
-Definition endo_star (a : Endo) (Hm : Monotone a) : Endo :=
-  fun d => lfp (star_operator a d) (star_operator_monotone a d Hm).
+  Definition star_operator (a : Endo) (d : Domain) : Endo :=
+    fun (x : Domain) => d + a x.
 
-Lemma Endo_star_fixed_point_right (a : Endo) (Hm : Monotone a) (d : Domain) :
-  star_operator a d (endo_star a Hm d) = (endo_star a Hm d).
-Proof.
-  apply lfp_is_fixed_point.
-Qed.
+  Lemma star_operator_monotone (a : Endo) (d : Domain) (Hm : Monotone a) :
+    Monotone (star_operator a d).
+  Proof.
+    unfold Monotone, star_operator.
+    intros x y Hleq.
+    apply domain_plus_monotone_left, Hm, Hleq.
+  Qed.
 
-Lemma endo_star_make_right : forall (x : Endo) (Hm : Monotone x),
-    1 + x * endo_star x Hm = endo_star x Hm.
-Proof.
-  intros x Hm.
-  extensionality d.
-  apply Endo_star_fixed_point_right.
-Qed.
+  Definition endo_star (a : Endo) (Hm : Monotone a) : Endo :=
+    fun d => lfp (star_operator a d) (star_operator_monotone a d Hm).
 
-Lemma endo_star_destruct_left : forall (a b : Endo) (Hm : Monotone a),
-    a * b <== b -> endo_star a Hm * b <== b.
-Proof.
-  intros a b Hm H.
-  apply endo_leq_pointwise_into; intro x.
-  apply inf_is_glb.
-  apply domain_plus_is_lub.
-  - apply domain_leq_refl.
-  - exact (endo_leq_pointwise_elim (a * b) b x H).
-Qed.
+  Lemma Endo_star_fixed_point_right (a : Endo) (Hm : Monotone a) (d : Domain) :
+    star_operator a d (endo_star a Hm d) = (endo_star a Hm d).
+  Proof.
+    apply lfp_is_fixed_point.
+  Qed.
 
-Fixpoint pow (a : Endo) (n : nat) : Endo :=
-  match n with
-    | O => 1
-    | S n' => a * pow a n'
-  end.
+  Lemma endo_star_make_right : forall (x : Endo) (Hm : Monotone x),
+      1 + x * endo_star x Hm = endo_star x Hm.
+  Proof.
+    intros x Hm.
+    extensionality d.
+    apply Endo_star_fixed_point_right.
+  Qed.
 
-Lemma pow_in_powerset : forall (a : Endo) (n : nat) (d : Domain),
-  In _ (Im _ _ (Im _ _ (Full_set nat) (pow a)) (fun f => f d)) ((pow a n) d).
-Proof.
-  intros a n d.
-  exact (Im_intro _ _ (Im _ _ (Full_set nat) (pow a)) (fun f => f d) (pow a n)
-           (Im_intro _ _ (Full_set nat) (pow a) n (Full_intro nat n) (pow a n) eq_refl)
-           ((pow a n) d) eq_refl).
-Qed.
-
-Lemma endo_dot_monotone_left : forall (z : Endo), Monotone z ->
-    forall (x y : Endo), x <== y -> z * x <== z * y.
-Proof.
-  intros z Hm x y Hleq.
-  apply endo_leq_pointwise_into; intro d.
-  apply (Hm (x d) (y d)).
-  exact (endo_leq_pointwise_elim x y d Hleq).
-Qed.
-
-Lemma endo_dot_monotone_right : forall x y z, x <== y -> x * z <== y * z.
-Proof.
-  intros x y z H.
-  unfold leq, Endo_LeqOp in *.
-  now rewrite <- endo_dot_distr_left, H.
-Qed.
-
-Lemma endo_dot_distr_leq_right : forall (z : Endo), Monotone z ->
-    forall (x y : Endo), z * x + z * y <== z * (x + y).
-Proof.
-  intros z Hm x y.
-  apply endo_plus_is_lub; apply (endo_dot_monotone_left z Hm);
-    [ apply endo_leq_plus_left | apply endo_leq_plus_right ].
-Qed.
-
-Lemma endo_star_monotone_in_d : forall (a : Endo) (Hm : Monotone a),
-    Monotone (endo_star a Hm).
-Proof.
-  intros a Hm d1 d2 Hd.
-  unfold endo_star.
-  apply lfp_leq.
-  intro x; unfold star_operator.
-  rewrite (domain_plus_com d1 (a x)), (domain_plus_com d2 (a x)).
-  apply domain_plus_monotone_left; exact Hd.
-Qed.
-
-Lemma id_monotone : Monotone (@id Domain).
-Proof. intros x y H; exact H. Qed.
-
-Lemma compose_monotone : forall (f g : Endo),
-    Monotone f -> Monotone g -> Monotone (compose f g).
-Proof.
-  intros f g Hf Hg x y H; unfold compose.
-  apply Hf, Hg, H.
-Qed.
-
-Lemma czero_monotone : Monotone (fun _ : Domain => (zero : Domain)).
-Proof. intros x y H; apply domain_leq_refl. Qed.
-
-Lemma cplus_monotone : forall (a b : Endo),
-    Monotone a -> Monotone b -> Monotone (fun d => a d + b d).
-Proof.
-  intros a b Ha Hb x y H.
-  apply domain_plus_is_lub.
-  - apply (domain_leq_trans _ (a y) _); [ apply Ha; exact H | apply domain_leq_plus_left ].
-  - apply (domain_leq_trans _ (b y) _); [ apply Hb; exact H | apply domain_leq_plus_right ].
-Qed.
-
-Lemma domain_lub_Im_plus : forall (a b : Endo) (X : Ensemble Domain),
-    domain_lub (Im _ _ X (fun d => a d + b d))
-    = domain_lub (Im _ _ X a) + domain_lub (Im _ _ X b).
-Proof.
-  intros a b X.
-  extensionality i.
-  apply Extensionality_Ensembles; split; intros t Ht.
-  - destruct Ht as [D [HD Ht]]; destruct HD as [x Hx D HDeq]; subst D.
-    destruct Ht as [t Ht | t Ht].
-    + left; exists (a x); split; [ exact (Im_intro _ _ X a x Hx _ eq_refl) | exact Ht ].
-    + right; exists (b x); split; [ exact (Im_intro _ _ X b x Hx _ eq_refl) | exact Ht ].
-  - destruct Ht as [t Ht | t Ht]; destruct Ht as [D [HD Ht]];
-      destruct HD as [x Hx D HDeq]; subst D;
-      exists (a x + b x); split;
-      try (exact (Im_intro _ _ X (fun d => a d + b d) x Hx _ eq_refl)).
-    + apply Union_introl; exact Ht.
-    + apply Union_intror; exact Ht.
-Qed.
-
-Lemma sig_eq : forall {A} {P : A -> Prop} (a b : sig P),
-    proj1_sig a = proj1_sig b -> a = b.
-Proof.
-  intros A P [f Hf] [g Hg] H; simpl in H; subst g.
-  f_equal; apply proof_irrelevance.
-Qed.
-
-Definition MonotoneEndo := { f : Endo | Monotone f }.
-
-Definition me_fn (a : MonotoneEndo) : Endo := proj1_sig a.
-Definition me_mono (a : MonotoneEndo) : Monotone (me_fn a) := proj2_sig a.
-
-Definition me_one : MonotoneEndo := exist _ (@id Domain) id_monotone.
-Definition me_dot (a b : MonotoneEndo) : MonotoneEndo :=
-  exist _ (compose (me_fn a) (me_fn b)) (compose_monotone _ _ (me_mono a) (me_mono b)).
-Definition me_zero : MonotoneEndo := exist _ (fun _ => zero) czero_monotone.
-Definition me_plus (a b : MonotoneEndo) : MonotoneEndo :=
-  exist _ (fun d => me_fn a d + me_fn b d) (cplus_monotone _ _ (me_mono a) (me_mono b)).
-Definition me_star (a : MonotoneEndo) : MonotoneEndo :=
-  exist _ (endo_star (me_fn a) (me_mono a)) (endo_star_monotone_in_d (me_fn a) (me_mono a)).
-
-Instance ME_MonoidOps : Monoid_Ops MonotoneEndo := { one := me_one; dot := me_dot }.
-Instance ME_SemiLatticeOps : SemiLattice_Ops MonotoneEndo := { zero := me_zero; plus := me_plus }.
-Instance ME_LeqOp : Leq_Op MonotoneEndo := { leq a b := me_fn a <== me_fn b }.
-Instance ME_StarOp : Star_Op MonotoneEndo := { star := me_star }.
-
-Instance ME_Monoid : Monoid (Mo := ME_MonoidOps).
-Proof. split; intros; apply sig_eq; reflexivity. Qed.
-
-Instance ME_PartiallyOrdered : PartiallyOrdered (Lo := ME_LeqOp).
-Proof.
-  split.
-  - intro a; apply endo_leq_refl.
-  - intros x y Hxy Hyx; apply sig_eq; apply endo_leq_antisym; assumption.
-  - intros x y z; apply endo_leq_trans.
-Qed.
-
-Instance ME_SemiLattice : SemiLattice (SLo := ME_SemiLatticeOps) (Lo := ME_LeqOp).
-Proof.
-  refine {| PO_SemiLattice := ME_PartiallyOrdered |}; intros.
-  - split; intro H.
-    + apply sig_eq; apply (proj1 (endo_leq_plus_def _ _)); exact H.
-    + change (me_fn x <== me_fn y);
-        apply (proj2 (endo_leq_plus_def _ _)); exact (f_equal me_fn H).
-  - apply sig_eq; apply endo_plus_neutral_left.
-  - apply sig_eq; apply endo_plus_idem.
-  - apply sig_eq; apply endo_plus_assoc.
-  - apply sig_eq; apply endo_plus_com.
-Qed.
-
-Instance ME_LeftHandedIdemSemiRing :
-    LeftHandedIdemSemiRing (Mo := ME_MonoidOps) (SLo := ME_SemiLatticeOps) (Lo := ME_LeqOp).
-Proof.
-  refine {| LHISR_Monoid := ME_Monoid; LHISR_SemiLattice := ME_SemiLattice |}; intros.
-  - apply sig_eq; reflexivity.
-  - apply sig_eq; reflexivity.
-  - apply (endo_dot_distr_leq_right (me_fn z) (me_mono z)).
-Qed.
-
-Instance ME_LeftHandedKleneeAlgebra :
-    LeftHandedKleneeAlgebra (Mo := ME_MonoidOps) (SLo := ME_SemiLatticeOps)
-                            (So := ME_StarOp) (Lo := ME_LeqOp).
-Proof.
-  refine {| LHKA_LHISR := ME_LeftHandedIdemSemiRing |}; intros.
-  - apply sig_eq; apply endo_star_make_right.
-  - apply (endo_star_destruct_left (me_fn a) (me_fn b) (me_mono a) H).
-Qed.
-
-Definition Continuous (a : Endo) : Prop :=
-  forall (X : Ensemble Domain), a (domain_lub X) = domain_lub (Im _ _ X a).
-
-Lemma endo_continuous_binary : forall (a : Endo), Continuous a ->
-    forall (x y : Domain), a (x + y) = a x + a y.
-Proof.
-  intros a Hc x y.
-  replace (x + y) with (domain_lub (Union _ (Singleton _ x) (Singleton _ y)))
-    by now rewrite domain_lub_union, 2 domain_lub_singleton.
-  now rewrite Hc, Im_union, 2 Im_singleton,
-              domain_lub_union, 2 domain_lub_singleton.
-Qed.
-
-Lemma endo_dot_distr_right : forall (z : Endo), Continuous z ->
-    forall (x y : Endo), z * (x + y) = z * x + z * y.
-Proof. intros z Hc x y; extensionality d; apply endo_continuous_binary, Hc. Qed.
-
-Lemma endo_preserves_zero : forall (a : Endo), Continuous a -> a zero = zero.
-Proof.
-  intros a Hc.
-  now rewrite <- domain_lub_empty, Hc, image_empty.
-Qed.
-
-Lemma endo_dot_ann_right : forall (x : Endo), Continuous x -> x * 0 = 0.
-Proof. intros x Hc; extensionality d; apply endo_preserves_zero, Hc. Qed.
-
-Lemma Endo_star_fixed_point_left (a : Endo) (Hc : Continuous a) (Hm : Monotone a) (d : Domain) :
-  star_operator (endo_star a Hm) d (a d) = (endo_star a Hm d).
-Proof.
-  apply leq_antisym.
-  - apply inf_is_glb; intros x Hx.
-    apply (domain_leq_trans _ (d + a x) x).
-    + apply domain_plus_monotone_left.
-      apply inf_is_glb.
-      unfold In, star_operator.
-      rewrite <- (endo_continuous_binary a Hc).
-      apply Hm, Hx.
-    + exact Hx.
-
-  - apply inf_is_glb.
-    unfold In, star_operator.
-    rewrite (endo_continuous_binary a Hc).
-    apply domain_plus_monotone_left.
-    change (star_operator a (a d) (endo_star a Hm (a d)) <== endo_star a Hm (a d)).
-    rewrite Endo_star_fixed_point_right.
-    apply domain_leq_refl.
-Qed.
-
-Lemma endo_star_make_left : forall (x : Endo) (Hc : Continuous x) (Hm : Monotone x),
-    1 + endo_star x Hm * x = endo_star x Hm.
-Proof.
-  intros x Hc Hm.
-  extensionality d.
-  apply Endo_star_fixed_point_left, Hc.
-Qed.
-
-Lemma pow_continuous : forall (a : Endo), Continuous a ->
-    forall n, Continuous (pow a n).
-Proof.
-  intros a Hc.
-  induction n as [| n IH].
-  - intro X.
-    change (pow a 0) with (@id Domain).
-    rewrite Im_id.
-    reflexivity.
-  - intro X.
-    change (pow a (S n)) with (compose a (pow a n)).
-    unfold compose at 1.
-    rewrite (IH X), (Hc (Im _ _ X (pow a n))), Im_compose.
-    reflexivity.
-Qed.
-
-Lemma star_sup_pow : forall (a : Endo) (Hc : Continuous a) (Hm : Monotone a),
-  endo_star a Hm = sup (Im _ _ (Full_set nat) (pow a)).
-Proof.
-  intros a Hc Hm.
-  extensionality d.
-  change (sup (Im _ _ (Full_set nat) (pow a)))
-    with (Endo_sup (Im _ _ (Full_set nat) (pow a))).
-  rewrite Endo_sup_pointwise.
-  set (Pd := Im _ _ (Im _ _ (Full_set nat) (pow a)) (fun f => f d)).
-  apply domain_leq_antisym.
-  - apply inf_is_glb.
-    unfold In, star_operator.
+  Lemma endo_star_destruct_left : forall (a b : Endo) (Hm : Monotone a),
+      a * b <== b -> endo_star a Hm * b <== b.
+  Proof.
+    intros a b Hm H.
+    apply endo_leq_pointwise_into; intro x.
+    apply inf_is_glb.
     apply domain_plus_is_lub.
-    + apply (proj1 (Domain_sup_is_lub Pd)).
-      exact (pow_in_powerset a 0 d).
-    + rewrite (Hc Pd).
-      apply (proj2 (Domain_sup_is_lub (Im _ _ Pd a))).
-      intros z Hz.
-      destruct Hz as [y Hy z Hzeq];
-        destruct Hy as [f Hf y Hyeq];
-        destruct Hf as [n Hn f Hfeq]; subst.
-      apply (proj1 (Domain_sup_is_lub Pd)).
-      exact (pow_in_powerset a (S n) d).
-  - apply (proj2 (Domain_sup_is_lub Pd)).
-    intros y Hy.
-    destruct Hy as [f Hf y Hyeq];
-      destruct Hf as [n Hn f Hfeq]; subst.
-    clear Hn.
-    induction n.
-    + change (pow a 0 d) with d.
-      apply (domain_leq_trans d (star_operator a d (endo_star a Hm d)) (endo_star a Hm d)).
-      * unfold star_operator; apply domain_leq_plus_left.
-      * rewrite Endo_star_fixed_point_right; apply domain_leq_refl.
-    + change (pow a (S n) d) with (a (pow a n d)).
-      apply (domain_leq_trans (a (pow a n d)) (a (endo_star a Hm d)) (endo_star a Hm d)).
-      * apply Hm; exact IHn.
-      * apply (domain_leq_trans (a (endo_star a Hm d)) (star_operator a d (endo_star a Hm d)) (endo_star a Hm d)).
-        -- unfold star_operator; apply domain_leq_plus_right.
-        -- rewrite Endo_star_fixed_point_right; apply domain_leq_refl.
-Qed.
+    - apply domain_leq_refl.
+    - exact (endo_leq_pointwise_elim (a * b) b x H).
+  Qed.
 
-Lemma endo_star_mem : forall (a : Endo) (Hc : Continuous a) (Hm : Monotone a)
-                             (d : Domain) (i : string) (t : Trace),
-    In _ (endo_star a Hm d i) t <-> exists n, In _ (pow a n d i) t.
-Proof.
-  intros a Hc Hm d i t.
-  assert (Hd : endo_star a Hm d
-             = domain_lub (Im _ _ (Im _ _ (Full_set nat) (pow a)) (fun f => f d))).
-  { rewrite (star_sup_pow a Hc Hm).
+  Fixpoint pow (a : Endo) (n : nat) : Endo :=
+    match n with
+      | O => 1
+      | S n' => a * pow a n'
+    end.
+
+  Lemma pow_in_powerset : forall (a : Endo) (n : nat) (d : Domain),
+    In _ (Im _ _ (Im _ _ (Full_set nat) (pow a)) (fun f => f d)) ((pow a n) d).
+  Proof.
+    intros a n d.
+    exact (Im_intro _ _ (Im _ _ (Full_set nat) (pow a)) (fun f => f d) (pow a n)
+             (Im_intro _ _ (Full_set nat) (pow a) n (Full_intro nat n) (pow a n) eq_refl)
+             ((pow a n) d) eq_refl).
+  Qed.
+
+  Lemma endo_dot_monotone_left : forall (z : Endo), Monotone z ->
+      forall (x y : Endo), x <== y -> z * x <== z * y.
+  Proof.
+    intros z Hm x y Hleq.
+    apply endo_leq_pointwise_into; intro d.
+    apply (Hm (x d) (y d)).
+    exact (endo_leq_pointwise_elim x y d Hleq).
+  Qed.
+
+  Lemma endo_dot_monotone_right : forall x y z, x <== y -> x * z <== y * z.
+  Proof.
+    intros x y z H.
+    unfold leq, Endo_LeqOp in *.
+    now rewrite <- endo_dot_distr_left, H.
+  Qed.
+
+  Lemma endo_dot_distr_leq_right : forall (z : Endo), Monotone z ->
+      forall (x y : Endo), z * x + z * y <== z * (x + y).
+  Proof.
+    intros z Hm x y.
+    apply endo_plus_is_lub; apply (endo_dot_monotone_left z Hm);
+      [ apply endo_leq_plus_left | apply endo_leq_plus_right ].
+  Qed.
+
+  Lemma endo_star_monotone_in_d : forall (a : Endo) (Hm : Monotone a),
+      Monotone (endo_star a Hm).
+  Proof.
+    intros a Hm d1 d2 Hd.
+    unfold endo_star.
+    apply lfp_leq.
+    intro x; unfold star_operator.
+    rewrite (domain_plus_com d1 (a x)), (domain_plus_com d2 (a x)).
+    apply domain_plus_monotone_left; exact Hd.
+  Qed.
+
+  Lemma id_monotone : Monotone (@id Domain).
+  Proof. intros x y H; exact H. Qed.
+
+  Lemma compose_monotone : forall (f g : Endo),
+      Monotone f -> Monotone g -> Monotone (compose f g).
+  Proof.
+    intros f g Hf Hg x y H; unfold compose.
+    apply Hf, Hg, H.
+  Qed.
+
+  Lemma czero_monotone : Monotone (fun _ : Domain => (zero : Domain)).
+  Proof. intros x y H; apply domain_leq_refl. Qed.
+
+  Lemma cplus_monotone : forall (a b : Endo),
+      Monotone a -> Monotone b -> Monotone (fun d => a d + b d).
+  Proof.
+    intros a b Ha Hb x y H.
+    apply domain_plus_is_lub.
+    - apply (domain_leq_trans _ (a y) _); [ apply Ha; exact H | apply domain_leq_plus_left ].
+    - apply (domain_leq_trans _ (b y) _); [ apply Hb; exact H | apply domain_leq_plus_right ].
+  Qed.
+
+  Lemma domain_lub_Im_plus : forall (a b : Endo) (X : Ensemble Domain),
+      domain_lub (Im _ _ X (fun d => a d + b d))
+      = domain_lub (Im _ _ X a) + domain_lub (Im _ _ X b).
+  Proof.
+    intros a b X.
+    extensionality i.
+    apply Extensionality_Ensembles; split; intros t Ht.
+    - destruct Ht as [D [HD Ht]]; destruct HD as [x Hx D HDeq]; subst D.
+      destruct Ht as [t Ht | t Ht].
+      + left; exists (a x); split; [ exact (Im_intro _ _ X a x Hx _ eq_refl) | exact Ht ].
+      + right; exists (b x); split; [ exact (Im_intro _ _ X b x Hx _ eq_refl) | exact Ht ].
+    - destruct Ht as [t Ht | t Ht]; destruct Ht as [D [HD Ht]];
+        destruct HD as [x Hx D HDeq]; subst D;
+        exists (a x + b x); split;
+        try (exact (Im_intro _ _ X (fun d => a d + b d) x Hx _ eq_refl)).
+      + apply Union_introl; exact Ht.
+      + apply Union_intror; exact Ht.
+  Qed.
+
+  Lemma sig_eq : forall {A} {P : A -> Prop} (a b : sig P),
+      proj1_sig a = proj1_sig b -> a = b.
+  Proof.
+    intros A P [f Hf] [g Hg] H; simpl in H; subst g.
+    f_equal; apply proof_irrelevance.
+  Qed.
+
+  Definition MonotoneEndo := { f : Endo | Monotone f }.
+
+  Definition me_fn (a : MonotoneEndo) : Endo := proj1_sig a.
+  Definition me_mono (a : MonotoneEndo) : Monotone (me_fn a) := proj2_sig a.
+
+  Definition me_one : MonotoneEndo := exist _ (@id Domain) id_monotone.
+  Definition me_dot (a b : MonotoneEndo) : MonotoneEndo :=
+    exist _ (compose (me_fn a) (me_fn b)) (compose_monotone _ _ (me_mono a) (me_mono b)).
+  Definition me_zero : MonotoneEndo := exist _ (fun _ => zero) czero_monotone.
+  Definition me_plus (a b : MonotoneEndo) : MonotoneEndo :=
+    exist _ (fun d => me_fn a d + me_fn b d) (cplus_monotone _ _ (me_mono a) (me_mono b)).
+  Definition me_star (a : MonotoneEndo) : MonotoneEndo :=
+    exist _ (endo_star (me_fn a) (me_mono a)) (endo_star_monotone_in_d (me_fn a) (me_mono a)).
+
+  Global Instance ME_MonoidOps : Monoid_Ops MonotoneEndo := { one := me_one; dot := me_dot }.
+  Global Instance ME_SemiLatticeOps : SemiLattice_Ops MonotoneEndo := { zero := me_zero; plus := me_plus }.
+  Global Instance ME_LeqOp : Leq_Op MonotoneEndo := { leq a b := me_fn a <== me_fn b }.
+  Global Instance ME_StarOp : Star_Op MonotoneEndo := { star := me_star }.
+
+  Global Instance ME_Monoid : Monoid (Mo := ME_MonoidOps).
+  Proof. split; intros; apply sig_eq; reflexivity. Qed.
+
+  Global Instance ME_PartiallyOrdered : PartiallyOrdered (Lo := ME_LeqOp).
+  Proof.
+    split.
+    - intro a; apply endo_leq_refl.
+    - intros x y Hxy Hyx; apply sig_eq; apply endo_leq_antisym; assumption.
+    - intros x y z; apply endo_leq_trans.
+  Qed.
+
+  Global Instance ME_SemiLattice : SemiLattice (SLo := ME_SemiLatticeOps) (Lo := ME_LeqOp).
+  Proof.
+    refine {| PO_SemiLattice := ME_PartiallyOrdered |}; intros.
+    - split; intro H.
+      + apply sig_eq; apply (proj1 (endo_leq_plus_def _ _)); exact H.
+      + change (me_fn x <== me_fn y);
+          apply (proj2 (endo_leq_plus_def _ _)); exact (f_equal me_fn H).
+    - apply sig_eq; apply endo_plus_neutral_left.
+    - apply sig_eq; apply endo_plus_idem.
+    - apply sig_eq; apply endo_plus_assoc.
+    - apply sig_eq; apply endo_plus_com.
+  Qed.
+
+  Global Instance ME_LeftHandedIdemSemiRing :
+      LeftHandedIdemSemiRing (Mo := ME_MonoidOps) (SLo := ME_SemiLatticeOps) (Lo := ME_LeqOp).
+  Proof.
+    refine {| LHISR_Monoid := ME_Monoid; LHISR_SemiLattice := ME_SemiLattice |}; intros.
+    - apply sig_eq; reflexivity.
+    - apply sig_eq; reflexivity.
+    - apply (endo_dot_distr_leq_right (me_fn z) (me_mono z)).
+  Qed.
+
+  Global Instance ME_LeftHandedKleneeAlgebra :
+      LeftHandedKleneeAlgebra (Mo := ME_MonoidOps) (SLo := ME_SemiLatticeOps)
+                              (So := ME_StarOp) (Lo := ME_LeqOp).
+  Proof.
+    refine {| LHKA_LHISR := ME_LeftHandedIdemSemiRing |}; intros.
+    - apply sig_eq; apply endo_star_make_right.
+    - apply (endo_star_destruct_left (me_fn a) (me_fn b) (me_mono a) H).
+  Qed.
+
+  Definition Continuous (a : Endo) : Prop :=
+    forall (X : Ensemble Domain), a (domain_lub X) = domain_lub (Im _ _ X a).
+
+  Lemma endo_continuous_binary : forall (a : Endo), Continuous a ->
+      forall (x y : Domain), a (x + y) = a x + a y.
+  Proof.
+    intros a Hc x y.
+    replace (x + y) with (domain_lub (Union _ (Singleton _ x) (Singleton _ y)))
+      by now rewrite domain_lub_union, 2 domain_lub_singleton.
+    now rewrite Hc, Im_union, 2 Im_singleton,
+                domain_lub_union, 2 domain_lub_singleton.
+  Qed.
+
+  Lemma endo_dot_distr_right : forall (z : Endo), Continuous z ->
+      forall (x y : Endo), z * (x + y) = z * x + z * y.
+  Proof. intros z Hc x y; extensionality d; apply endo_continuous_binary, Hc. Qed.
+
+  Lemma endo_preserves_zero : forall (a : Endo), Continuous a -> a zero = zero.
+  Proof.
+    intros a Hc.
+    now rewrite <- domain_lub_empty, Hc, image_empty.
+  Qed.
+
+  Lemma endo_dot_ann_right : forall (x : Endo), Continuous x -> x * 0 = 0.
+  Proof. intros x Hc; extensionality d; apply endo_preserves_zero, Hc. Qed.
+
+  Lemma Endo_star_fixed_point_left (a : Endo) (Hc : Continuous a) (Hm : Monotone a) (d : Domain) :
+    star_operator (endo_star a Hm) d (a d) = (endo_star a Hm d).
+  Proof.
+    apply leq_antisym.
+    - apply inf_is_glb; intros x Hx.
+      apply (domain_leq_trans _ (d + a x) x).
+      + apply domain_plus_monotone_left.
+        apply inf_is_glb.
+        unfold In, star_operator.
+        rewrite <- (endo_continuous_binary a Hc).
+        apply Hm, Hx.
+      + exact Hx.
+
+    - apply inf_is_glb.
+      unfold In, star_operator.
+      rewrite (endo_continuous_binary a Hc).
+      apply domain_plus_monotone_left.
+      change (star_operator a (a d) (endo_star a Hm (a d)) <== endo_star a Hm (a d)).
+      rewrite Endo_star_fixed_point_right.
+      apply domain_leq_refl.
+  Qed.
+
+  Lemma endo_star_make_left : forall (x : Endo) (Hc : Continuous x) (Hm : Monotone x),
+      1 + endo_star x Hm * x = endo_star x Hm.
+  Proof.
+    intros x Hc Hm.
+    extensionality d.
+    apply Endo_star_fixed_point_left, Hc.
+  Qed.
+
+  Lemma pow_continuous : forall (a : Endo), Continuous a ->
+      forall n, Continuous (pow a n).
+  Proof.
+    intros a Hc.
+    induction n as [| n IH].
+    - intro X.
+      change (pow a 0) with (@id Domain).
+      rewrite Im_id.
+      reflexivity.
+    - intro X.
+      change (pow a (S n)) with (compose a (pow a n)).
+      unfold compose at 1.
+      rewrite (IH X), (Hc (Im _ _ X (pow a n))), Im_compose.
+      reflexivity.
+  Qed.
+
+  Lemma star_sup_pow : forall (a : Endo) (Hc : Continuous a) (Hm : Monotone a),
+    endo_star a Hm = sup (Im _ _ (Full_set nat) (pow a)).
+  Proof.
+    intros a Hc Hm.
+    extensionality d.
     change (sup (Im _ _ (Full_set nat) (pow a)))
       with (Endo_sup (Im _ _ (Full_set nat) (pow a))).
-    apply Endo_sup_pointwise. }
-  rewrite Hd; split.
-  - intros [D [HD Ht]].
-    destruct HD as [g Hg D HDeq]; subst D.
-    destruct Hg as [n Hn g Hgeq]; subst g.
-    exists n; exact Ht.
-  - intros [n Ht].
-    exists (pow a n d); split; [ exact (pow_in_powerset a n d) | exact Ht ].
-Qed.
+    rewrite Endo_sup_pointwise.
+    set (Pd := Im _ _ (Im _ _ (Full_set nat) (pow a)) (fun f => f d)).
+    apply domain_leq_antisym.
+    - apply inf_is_glb.
+      unfold In, star_operator.
+      apply domain_plus_is_lub.
+      + apply (proj1 (Domain_sup_is_lub Pd)).
+        exact (pow_in_powerset a 0 d).
+      + rewrite (Hc Pd).
+        apply (proj2 (Domain_sup_is_lub (Im _ _ Pd a))).
+        intros z Hz.
+        destruct Hz as [y Hy z Hzeq];
+          destruct Hy as [f Hf y Hyeq];
+          destruct Hf as [n Hn f Hfeq]; subst.
+        apply (proj1 (Domain_sup_is_lub Pd)).
+        exact (pow_in_powerset a (S n) d).
+    - apply (proj2 (Domain_sup_is_lub Pd)).
+      intros y Hy.
+      destruct Hy as [f Hf y Hyeq];
+        destruct Hf as [n Hn f Hfeq]; subst.
+      clear Hn.
+      induction n.
+      + change (pow a 0 d) with d.
+        apply (domain_leq_trans d (star_operator a d (endo_star a Hm d)) (endo_star a Hm d)).
+        * unfold star_operator; apply domain_leq_plus_left.
+        * rewrite Endo_star_fixed_point_right; apply domain_leq_refl.
+      + change (pow a (S n) d) with (a (pow a n d)).
+        apply (domain_leq_trans (a (pow a n d)) (a (endo_star a Hm d)) (endo_star a Hm d)).
+        * apply Hm; exact IHn.
+        * apply (domain_leq_trans (a (endo_star a Hm d)) (star_operator a d (endo_star a Hm d)) (endo_star a Hm d)).
+          -- unfold star_operator; apply domain_leq_plus_right.
+          -- rewrite Endo_star_fixed_point_right; apply domain_leq_refl.
+  Qed.
 
-Lemma endo_star_continuous : forall (a : Endo) (Hc : Continuous a) (Hm : Monotone a),
-    Continuous (endo_star a Hm).
-Proof.
-  intros a Hc Hm X.
-  extensionality i.
-  apply Extensionality_Ensembles; split; intros t Ht.
-  - apply (proj1 (endo_star_mem a Hc Hm (domain_lub X) i t)) in Ht.
-    destruct Ht as [n Ht].
-    rewrite (pow_continuous a Hc n X) in Ht.
-    destruct Ht as [D [HD Ht]].
-    destruct HD as [x Hx D HDeq]; subst D.
-    exists (endo_star a Hm x); split.
-    + exact (Im_intro _ _ X (endo_star a Hm) x Hx _ eq_refl).
-    + apply (proj2 (endo_star_mem a Hc Hm x i t)).
+  Lemma endo_star_mem : forall (a : Endo) (Hc : Continuous a) (Hm : Monotone a)
+                               (d : Domain) (i : list Σ) (t : Trace),
+      In _ (endo_star a Hm d i) t <-> exists n, In _ (pow a n d i) t.
+  Proof.
+    intros a Hc Hm d i t.
+    assert (Hd : endo_star a Hm d
+               = domain_lub (Im _ _ (Im _ _ (Full_set nat) (pow a)) (fun f => f d))).
+    { rewrite (star_sup_pow a Hc Hm).
+      change (sup (Im _ _ (Full_set nat) (pow a)))
+        with (Endo_sup (Im _ _ (Full_set nat) (pow a))).
+      apply Endo_sup_pointwise. }
+    rewrite Hd; split.
+    - intros [D [HD Ht]].
+      destruct HD as [g Hg D HDeq]; subst D.
+      destruct Hg as [n Hn g Hgeq]; subst g.
       exists n; exact Ht.
-  - destruct Ht as [D [HD Ht]].
-    destruct HD as [x Hx D HDeq]; subst D.
-    apply (proj1 (endo_star_mem a Hc Hm x i t)) in Ht.
-    destruct Ht as [n Ht].
-    apply (proj2 (endo_star_mem a Hc Hm (domain_lub X) i t)).
-    exists n.
-    rewrite (pow_continuous a Hc n X).
-    exists (pow a n x); split.
-    + exact (Im_intro _ _ X (pow a n) x Hx _ eq_refl).
-    + exact Ht.
-Qed.
+    - intros [n Ht].
+      exists (pow a n d); split; [ exact (pow_in_powerset a n d) | exact Ht ].
+  Qed.
 
-Lemma endo_dot_sup_left : forall (b : Endo), Continuous b ->
-    forall (X : Ensemble Endo),
-    b * (sup X) = sup (Im _ _ X (fun x => b * x)).
-Proof.
-  intros b Hc X.
-  extensionality d.
-  change ((b * sup X) d) with (b (sup X d)).
-  change (sup X) with (Endo_sup X); change (sup (Im _ _ X (fun x => b * x)))
-    with (Endo_sup (Im _ _ X (fun x => b * x))).
-  rewrite Endo_sup_pointwise, (Hc _), Endo_sup_pointwise.
-  f_equal.
-  apply Extensionality_Ensembles; split; intros g Hg.
-  - destruct Hg as [y Hy g Hgeq]; destruct Hy as [f Hf y Hyeq]; subst.
-    apply (Im_intro _ _ (Im _ _ X (fun x => b * x)) (fun h => h d) (b * f)).
-    + exact (Im_intro _ _ X (fun x => b * x) f Hf _ eq_refl).
-    + reflexivity.
-  - destruct Hg as [y Hy g Hgeq]; destruct Hy as [f Hf y Hyeq]; subst.
-    apply (Im_intro _ _ (Im _ _ X (fun f => f d)) b (f d)).
-    + exact (Im_intro _ _ X (fun f => f d) f Hf _ eq_refl).
-    + reflexivity.
-Qed.
+  Lemma endo_star_continuous : forall (a : Endo) (Hc : Continuous a) (Hm : Monotone a),
+      Continuous (endo_star a Hm).
+  Proof.
+    intros a Hc Hm X.
+    extensionality i.
+    apply Extensionality_Ensembles; split; intros t Ht.
+    - apply (proj1 (endo_star_mem a Hc Hm (domain_lub X) i t)) in Ht.
+      destruct Ht as [n Ht].
+      rewrite (pow_continuous a Hc n X) in Ht.
+      destruct Ht as [D [HD Ht]].
+      destruct HD as [x Hx D HDeq]; subst D.
+      exists (endo_star a Hm x); split.
+      + exact (Im_intro _ _ X (endo_star a Hm) x Hx _ eq_refl).
+      + apply (proj2 (endo_star_mem a Hc Hm x i t)).
+        exists n; exact Ht.
+    - destruct Ht as [D [HD Ht]].
+      destruct HD as [x Hx D HDeq]; subst D.
+      apply (proj1 (endo_star_mem a Hc Hm x i t)) in Ht.
+      destruct Ht as [n Ht].
+      apply (proj2 (endo_star_mem a Hc Hm (domain_lub X) i t)).
+      exists n.
+      rewrite (pow_continuous a Hc n X).
+      exists (pow a n x); split.
+      + exact (Im_intro _ _ X (pow a n) x Hx _ eq_refl).
+      + exact Ht.
+  Qed.
 
-Lemma endo_star_destruct_right : forall (a b : Endo)
-                                        (Hca : Continuous a) (Hma : Monotone a)
-                                        (Hcb : Continuous b),
-    b * a <== b -> b * endo_star a Hma <== b.
-Proof.
-  intros a b Hca Hma Hcb Hba.
-  rewrite (star_sup_pow a Hca Hma), (endo_dot_sup_left b Hcb).
-  apply sup_is_lub.
-  intros f [g [n _ Hg] Hf]; subst.
-  induction n.
-  - apply leq_refl.
-  - change (b * a * pow a n <== b).
-    apply (leq_trans (b * a * pow a n) (b * pow a n) b).
-    + exact (endo_dot_monotone_right (b * a) b (pow a n) Hba).
-    + exact IHn.
-Qed.
+  Lemma endo_dot_sup_left : forall (b : Endo), Continuous b ->
+      forall (X : Ensemble Endo),
+      b * (sup X) = sup (Im _ _ X (fun x => b * x)).
+  Proof.
+    intros b Hc X.
+    extensionality d.
+    change ((b * sup X) d) with (b (sup X d)).
+    change (sup X) with (Endo_sup X); change (sup (Im _ _ X (fun x => b * x)))
+      with (Endo_sup (Im _ _ X (fun x => b * x))).
+    rewrite Endo_sup_pointwise, (Hc _), Endo_sup_pointwise.
+    f_equal.
+    apply Extensionality_Ensembles; split; intros g Hg.
+    - destruct Hg as [y Hy g Hgeq]; destruct Hy as [f Hf y Hyeq]; subst.
+      apply (Im_intro _ _ (Im _ _ X (fun x => b * x)) (fun h => h d) (b * f)).
+      + exact (Im_intro _ _ X (fun x => b * x) f Hf _ eq_refl).
+      + reflexivity.
+    - destruct Hg as [y Hy g Hgeq]; destruct Hy as [f Hf y Hyeq]; subst.
+      apply (Im_intro _ _ (Im _ _ X (fun f => f d)) b (f d)).
+      + exact (Im_intro _ _ X (fun f => f d) f Hf _ eq_refl).
+      + reflexivity.
+  Qed.
 
-Lemma id_continuous : Continuous (@id Domain).
-Proof. intro X; unfold id; rewrite Im_id; reflexivity. Qed.
+  Lemma endo_star_destruct_right : forall (a b : Endo)
+                                          (Hca : Continuous a) (Hma : Monotone a)
+                                          (Hcb : Continuous b),
+      b * a <== b -> b * endo_star a Hma <== b.
+  Proof.
+    intros a b Hca Hma Hcb Hba.
+    rewrite (star_sup_pow a Hca Hma), (endo_dot_sup_left b Hcb).
+    apply sup_is_lub.
+    intros f [g [n _ Hg] Hf]; subst.
+    induction n.
+    - apply leq_refl.
+    - change (b * a * pow a n <== b).
+      apply (leq_trans (b * a * pow a n) (b * pow a n) b).
+      + exact (endo_dot_monotone_right (b * a) b (pow a n) Hba).
+      + exact IHn.
+  Qed.
 
-Lemma czero_continuous : Continuous (fun _ : Domain => (zero : Domain)).
-Proof.
-  intro X.
-  extensionality i.
-  apply Extensionality_Ensembles; split; intros t Ht.
-  - destruct Ht.
-  - destruct Ht as [D [HD Ht]]; destruct HD as [x Hx D HDeq]; subst D; destruct Ht.
-Qed.
+  Lemma id_continuous : Continuous (@id Domain).
+  Proof. intro X; unfold id; rewrite Im_id; reflexivity. Qed.
 
-Lemma compose_continuous : forall (f g : Endo),
-    Continuous f -> Continuous g -> Continuous (compose f g).
-Proof.
-  intros f g Hf Hg X; unfold compose.
-  rewrite (Hg X), (Hf (Im _ _ X g)), Im_compose.
-  reflexivity.
-Qed.
+  Lemma czero_continuous : Continuous (fun _ : Domain => (zero : Domain)).
+  Proof.
+    intro X.
+    extensionality i.
+    apply Extensionality_Ensembles; split; intros t Ht.
+    - destruct Ht.
+    - destruct Ht as [D [HD Ht]]; destruct HD as [x Hx D HDeq]; subst D; destruct Ht.
+  Qed.
 
-Lemma cplus_continuous : forall (a b : Endo),
-    Continuous a -> Continuous b -> Continuous (fun d => a d + b d).
-Proof.
-  intros a b Ha Hb X.
-  change ((fun d => a d + b d) (domain_lub X)) with (a (domain_lub X) + b (domain_lub X)).
-  rewrite (Ha X), (Hb X).
-  symmetry; apply domain_lub_Im_plus.
-Qed.
+  Lemma compose_continuous : forall (f g : Endo),
+      Continuous f -> Continuous g -> Continuous (compose f g).
+  Proof.
+    intros f g Hf Hg X; unfold compose.
+    rewrite (Hg X), (Hf (Im _ _ X g)), Im_compose.
+    reflexivity.
+  Qed.
 
-Definition СontinuousEndo := { f : MonotoneEndo | Continuous (me_fn f) }.
+  Lemma cplus_continuous : forall (a b : Endo),
+      Continuous a -> Continuous b -> Continuous (fun d => a d + b d).
+  Proof.
+    intros a b Ha Hb X.
+    change ((fun d => a d + b d) (domain_lub X)) with (a (domain_lub X) + b (domain_lub X)).
+    rewrite (Ha X), (Hb X).
+    symmetry; apply domain_lub_Im_plus.
+  Qed.
 
-Definition ce_me (a : СontinuousEndo) : MonotoneEndo := proj1_sig a.
-Definition ce_fn (a : СontinuousEndo) : Endo := me_fn (ce_me a).
-Definition ce_mono (a : СontinuousEndo) : Monotone (ce_fn a) := me_mono (ce_me a).
-Definition ce_cont (a : СontinuousEndo) : Continuous (ce_fn a) := proj2_sig a.
+  Definition СontinuousEndo := { f : MonotoneEndo | Continuous (me_fn f) }.
 
-Lemma ce_eq : forall (a b : СontinuousEndo), ce_fn a = ce_fn b -> a = b.
-Proof. intros a b H; apply sig_eq, sig_eq, H. Qed.
+  Definition ce_me (a : СontinuousEndo) : MonotoneEndo := proj1_sig a.
+  Definition ce_fn (a : СontinuousEndo) : Endo := me_fn (ce_me a).
+  Definition ce_mono (a : СontinuousEndo) : Monotone (ce_fn a) := me_mono (ce_me a).
+  Definition ce_cont (a : СontinuousEndo) : Continuous (ce_fn a) := proj2_sig a.
 
-Definition ce_one : СontinuousEndo := exist _ me_one id_continuous.
-Definition ce_dot (a b : СontinuousEndo) : СontinuousEndo :=
-  exist _ (me_dot (ce_me a) (ce_me b)) (compose_continuous _ _ (ce_cont a) (ce_cont b)).
-Definition ce_zero : СontinuousEndo := exist _ me_zero czero_continuous.
-Definition ce_plus (a b : СontinuousEndo) : СontinuousEndo :=
-  exist _ (me_plus (ce_me a) (ce_me b)) (cplus_continuous _ _ (ce_cont a) (ce_cont b)).
-Definition ce_star (a : СontinuousEndo) : СontinuousEndo :=
-  exist _ (me_star (ce_me a)) (endo_star_continuous (ce_fn a) (ce_cont a) (ce_mono a)).
+  Lemma ce_eq : forall (a b : СontinuousEndo), ce_fn a = ce_fn b -> a = b.
+  Proof. intros a b H; apply sig_eq, sig_eq, H. Qed.
 
-Instance СE_MonoidOps : Monoid_Ops СontinuousEndo := { one := ce_one; dot := ce_dot }.
-Instance СE_SemiLatticeOps : SemiLattice_Ops СontinuousEndo := { zero := ce_zero; plus := ce_plus }.
-Instance СE_LeqOp : Leq_Op СontinuousEndo := { leq a b := ce_me a <== ce_me b }.
-Instance СE_StarOp : Star_Op СontinuousEndo := { star := ce_star }.
+  Definition ce_one : СontinuousEndo := exist _ me_one id_continuous.
+  Definition ce_dot (a b : СontinuousEndo) : СontinuousEndo :=
+    exist _ (me_dot (ce_me a) (ce_me b)) (compose_continuous _ _ (ce_cont a) (ce_cont b)).
+  Definition ce_zero : СontinuousEndo := exist _ me_zero czero_continuous.
+  Definition ce_plus (a b : СontinuousEndo) : СontinuousEndo :=
+    exist _ (me_plus (ce_me a) (ce_me b)) (cplus_continuous _ _ (ce_cont a) (ce_cont b)).
+  Definition ce_star (a : СontinuousEndo) : СontinuousEndo :=
+    exist _ (me_star (ce_me a)) (endo_star_continuous (ce_fn a) (ce_cont a) (ce_mono a)).
 
-Instance СE_Monoid : Monoid (Mo := СE_MonoidOps).
-Proof.
-  split.
-  - intros x y z; apply sig_eq; exact (dot_assoc (ce_me x) (ce_me y) (ce_me z)).
-  - intro x; apply sig_eq; exact (dot_neutral_left (ce_me x)).
-  - intro x; apply sig_eq; exact (dot_neutral_right (ce_me x)).
-Qed.
+  Global Instance СE_MonoidOps : Monoid_Ops СontinuousEndo := { one := ce_one; dot := ce_dot }.
+  Global Instance СE_SemiLatticeOps : SemiLattice_Ops СontinuousEndo := { zero := ce_zero; plus := ce_plus }.
+  Global Instance СE_LeqOp : Leq_Op СontinuousEndo := { leq a b := ce_me a <== ce_me b }.
+  Global Instance СE_StarOp : Star_Op СontinuousEndo := { star := ce_star }.
 
-Instance СE_PartiallyOrdered : PartiallyOrdered (Lo := СE_LeqOp).
-Proof.
-  split.
-  - intro a; exact (leq_refl (ce_me a)).
-  - intros x y Hxy Hyx; apply sig_eq; exact (leq_antisym (ce_me x) (ce_me y) Hxy Hyx).
-  - intros x y z Hxy Hyz; exact (leq_trans (ce_me x) (ce_me y) (ce_me z) Hxy Hyz).
-Qed.
+  Global Instance СE_Monoid : Monoid (Mo := СE_MonoidOps).
+  Proof.
+    split.
+    - intros x y z; apply sig_eq; exact (dot_assoc (ce_me x) (ce_me y) (ce_me z)).
+    - intro x; apply sig_eq; exact (dot_neutral_left (ce_me x)).
+    - intro x; apply sig_eq; exact (dot_neutral_right (ce_me x)).
+  Qed.
 
-Instance СE_SemiLattice : SemiLattice (SLo := СE_SemiLatticeOps) (Lo := СE_LeqOp).
-Proof.
-  refine {| PO_SemiLattice := СE_PartiallyOrdered |}.
-  - intros x y; split; intro H.
-    + apply sig_eq; exact (proj1 (leq_plus_def (ce_me x) (ce_me y)) H).
-    + exact (proj2 (leq_plus_def (ce_me x) (ce_me y)) (f_equal ce_me H)).
-  - intro x; apply sig_eq; exact (plus_neutral_left (ce_me x)).
-  - intro x; apply sig_eq; exact (plus_idem (ce_me x)).
-  - intros x y z; apply sig_eq; exact (plus_assoc (ce_me x) (ce_me y) (ce_me z)).
-  - intros x y; apply sig_eq; exact (plus_com (ce_me x) (ce_me y)).
-Qed.
+  Global Instance СE_PartiallyOrdered : PartiallyOrdered (Lo := СE_LeqOp).
+  Proof.
+    split.
+    - intro a; exact (leq_refl (ce_me a)).
+    - intros x y Hxy Hyx; apply sig_eq; exact (leq_antisym (ce_me x) (ce_me y) Hxy Hyx).
+    - intros x y z Hxy Hyz; exact (leq_trans (ce_me x) (ce_me y) (ce_me z) Hxy Hyz).
+  Qed.
 
-Instance СE_LeftHandedIdemSemiRing :
-    LeftHandedIdemSemiRing (Mo := СE_MonoidOps) (SLo := СE_SemiLatticeOps) (Lo := СE_LeqOp).
-Proof.
-  refine {| LHISR_Monoid := СE_Monoid; LHISR_SemiLattice := СE_SemiLattice |}.
-  - intro x; apply sig_eq; exact (dot_ann_left (ce_me x)).
-  - intros x y z; apply sig_eq; exact (dot_distr_left (ce_me x) (ce_me y) (ce_me z)).
-  - intros x y z; exact (dot_distr_leq_right (ce_me x) (ce_me y) (ce_me z)).
-Qed.
+  Global Instance СE_SemiLattice : SemiLattice (SLo := СE_SemiLatticeOps) (Lo := СE_LeqOp).
+  Proof.
+    refine {| PO_SemiLattice := СE_PartiallyOrdered |}.
+    - intros x y; split; intro H.
+      + apply sig_eq; exact (proj1 (leq_plus_def (ce_me x) (ce_me y)) H).
+      + exact (proj2 (leq_plus_def (ce_me x) (ce_me y)) (f_equal ce_me H)).
+    - intro x; apply sig_eq; exact (plus_neutral_left (ce_me x)).
+    - intro x; apply sig_eq; exact (plus_idem (ce_me x)).
+    - intros x y z; apply sig_eq; exact (plus_assoc (ce_me x) (ce_me y) (ce_me z)).
+    - intros x y; apply sig_eq; exact (plus_com (ce_me x) (ce_me y)).
+  Qed.
 
-Instance СE_LeftHandedKleneeAlgebra :
-    LeftHandedKleneeAlgebra (Mo := СE_MonoidOps) (SLo := СE_SemiLatticeOps)
-                            (So := СE_StarOp) (Lo := СE_LeqOp).
-Proof.
-  refine {| LHKA_LHISR := СE_LeftHandedIdemSemiRing |}.
-  - intro x; apply sig_eq; exact (star_make_right (ce_me x)).
-  - intros a b H; exact (star_destruct_left (ce_me a) (ce_me b) H).
-Qed.
+  Global Instance СE_LeftHandedIdemSemiRing :
+      LeftHandedIdemSemiRing (Mo := СE_MonoidOps) (SLo := СE_SemiLatticeOps) (Lo := СE_LeqOp).
+  Proof.
+    refine {| LHISR_Monoid := СE_Monoid; LHISR_SemiLattice := СE_SemiLattice |}.
+    - intro x; apply sig_eq; exact (dot_ann_left (ce_me x)).
+    - intros x y z; apply sig_eq; exact (dot_distr_left (ce_me x) (ce_me y) (ce_me z)).
+    - intros x y z; exact (dot_distr_leq_right (ce_me x) (ce_me y) (ce_me z)).
+  Qed.
 
-Instance СE_IdemSemiRing :
-    IdemSemiRing (Mo := СE_MonoidOps) (SLo := СE_SemiLatticeOps) (Lo := СE_LeqOp).
-Proof.
-  refine {| ISR_LHISR := СE_LeftHandedIdemSemiRing |}.
-  - intro x; apply ce_eq; exact (endo_dot_ann_right (ce_fn x) (ce_cont x)).
-  - intros z x y; apply ce_eq;
-      exact (endo_dot_distr_right (ce_fn z) (ce_cont z) (ce_fn x) (ce_fn y)).
-Qed.
+  Global Instance СE_LeftHandedKleneeAlgebra :
+      LeftHandedKleneeAlgebra (Mo := СE_MonoidOps) (SLo := СE_SemiLatticeOps)
+                              (So := СE_StarOp) (Lo := СE_LeqOp).
+  Proof.
+    refine {| LHKA_LHISR := СE_LeftHandedIdemSemiRing |}.
+    - intro x; apply sig_eq; exact (star_make_right (ce_me x)).
+    - intros a b H; exact (star_destruct_left (ce_me a) (ce_me b) H).
+  Qed.
 
-Instance CE_KleeneAlgebra :
-    KleeneAlgebra (Mo := СE_MonoidOps) (SLo := СE_SemiLatticeOps)
-                  (So := СE_StarOp) (Lo := СE_LeqOp).
-Proof.
-  refine {| KA_LHKA := СE_LeftHandedKleneeAlgebra; KA_ISR := СE_IdemSemiRing |}.
-  - intro x; apply ce_eq; exact (endo_star_make_left (ce_fn x) (ce_cont x) (ce_mono x)).
-  - intros a b H; exact (endo_star_destruct_right (ce_fn a) (ce_fn b)
-                           (ce_cont a) (ce_mono a) (ce_cont b) H).
-Qed.
+  Global Instance СE_IdemSemiRing :
+      IdemSemiRing (Mo := СE_MonoidOps) (SLo := СE_SemiLatticeOps) (Lo := СE_LeqOp).
+  Proof.
+    refine {| ISR_LHISR := СE_LeftHandedIdemSemiRing |}.
+    - intro x; apply ce_eq; exact (endo_dot_ann_right (ce_fn x) (ce_cont x)).
+    - intros z x y; apply ce_eq;
+        exact (endo_dot_distr_right (ce_fn z) (ce_cont z) (ce_fn x) (ce_fn y)).
+  Qed.
+
+  Global Instance CE_KleeneAlgebra :
+      KleeneAlgebra (Mo := СE_MonoidOps) (SLo := СE_SemiLatticeOps)
+                    (So := СE_StarOp) (Lo := СE_LeqOp).
+  Proof.
+    refine {| KA_LHKA := СE_LeftHandedKleneeAlgebra; KA_ISR := СE_IdemSemiRing |}.
+    - intro x; apply ce_eq; exact (endo_star_make_left (ce_fn x) (ce_cont x) (ce_mono x)).
+    - intros a b H; exact (endo_star_destruct_right (ce_fn a) (ce_fn b)
+                             (ce_cont a) (ce_mono a) (ce_cont b) H).
+  Qed.
+
+End Endo.

--- a/src/Endo.v
+++ b/src/Endo.v
@@ -7,7 +7,6 @@ From Coq Require Import Logic.ProofIrrelevance.
 Section Endo.
   Context `{tm : TM}.
 
-
   Definition Endo := Domain -> Domain.
 
   Global Instance Endo_MonoidOps : Monoid_Ops Endo := {

--- a/src/LFP.v
+++ b/src/LFP.v
@@ -1,5 +1,5 @@
-From klenee_complexity Require Import Algebraic_Structures Domain Conf.
-From Coq Require Import Program.Basics Strings.String.
+From klenee_complexity Require Import Algebraic_Structures Domain TM.
+From Coq Require Import Program.Basics.
 From Coq Require Import Sets.Powerset Sets.Image.
 From Coq Require Import Logic.FunctionalExtensionality.
 

--- a/src/TM.v
+++ b/src/TM.v
@@ -1,5 +1,6 @@
 Set Warnings "-stdlib-vector".
-From Coq Require Vectors.Vector.
+From Coq Require Import Lists.List Vectors.Vector Vectors.Fin.
+Import ListNotations.
 From klenee_complexity Require Import NEList.
 
 Section TuringMachines.
@@ -20,52 +21,129 @@ Section TuringMachines.
         work_tapes_indices : Vector.t nat work_tapes_num;
     }.
 
-    Definition Trace  := NEList Conf.
+    Definition get_input_symbol (c : Conf) : option Σ :=
+        nth_error (input c) (input_index c).
+
+    Record TransitionCond := {
+        input_symbol : Σ;
+        work_tapes_symbols : Vector.t Γ work_tapes_num;
+    }.
+
+    Inductive Move := Left | Right | Stay. 
+
+    Record TransitionAction := {
+        new_work_tapes_symbols : Vector.t Γ work_tapes_num;
+        input_move : Move;
+        work_tapes_moves : Vector.t Move work_tapes_num;
+    }.
+
+    Definition update_index (idx : nat) (move : Move) : nat :=
+        match move with
+        | Left => 
+            match idx with
+            | 0 => 0
+            | S n => n
+            end
+        | Right => S idx
+        | Stay => idx
+        end.
+
+    Definition update_tape (tape : list Γ) (idx : nat) (new_sym : Γ) : list Γ :=
+        (fix replace_nth (l : list Γ) (n : nat) (x : Γ) : list Γ :=
+            match l, n with
+            | [], _ => []
+            | h :: t, 0 => x :: t
+            | h :: t, S n' => h :: replace_nth t n' x
+            end) tape idx new_sym.
+    
+    Definition work_tapes_consistent
+        (c1 c2 : Conf) 
+        (cond : TransitionCond) 
+        (action : TransitionAction) : Prop :=
+            forall (i : nat) (H : i < work_tapes_num),
+                let fin_idx := of_nat_lt H in
+
+                let tape1 := Vector.nth (work_tapes c1) fin_idx in
+                let idx1 := Vector.nth (work_tapes_indices c1) fin_idx in
+                let exp_sym := Vector.nth (work_tapes_symbols cond) fin_idx in
+                let tape2 := Vector.nth (work_tapes c2) fin_idx in
+                let idx2 := Vector.nth (work_tapes_indices c2) fin_idx in
+                let new_sym := Vector.nth (new_work_tapes_symbols action) fin_idx in
+                let mv := Vector.nth (work_tapes_moves action) fin_idx in
+                
+                (nth_error tape1 idx1 = Some exp_sym) /\
+                (tape2 = update_tape tape1 idx1 new_sym) /\
+                (idx2 = update_index idx1 mv).
+    
+
+    Record P := {
+        t_cond : TransitionCond;
+        t_action: TransitionAction;
+    }.
 
     Class TM := {
         init : Q;
         final : Q -> bool;
 
-        transitions : Type;
-        do_transition : Conf -> Conf;
+        exist_transition : P -> Conf -> Conf -> Prop;
     }.
+
+    Definition DTransitions := Q * TransitionCond -> Q * TransitionAction.
 
     Record DTM := {
         d_init : Q;
         d_final : Q -> bool;
+
+        d_transitions : DTransitions;
     }.
 
-    Inductive Move := Left | Right | Stay. 
-
-    Definition DTransitions (n : nat) :=
-        Q * Σ * (Vector.t Γ n) -> 
-        Q * (Vector.t Γ n) * Move * (Vector.t Move n).
+    Definition exist_d_transition (d_transitions : DTransitions) (p : P) (c1 c2 : Conf) := 
+        let (cond, action) := p in
+        let (expected_new_state, expected_action) := d_transitions (state c1, cond) in
+        
+        (get_input_symbol c1 = Some (input_symbol cond)) /\
+        (expected_action = action) /\
+        (expected_new_state = state c2) /\
+        (input c2 = input c1) /\
+        (input_index c2 = update_index (input_index c1) (input_move action)) /\
+        (work_tapes_consistent c1 c2 cond action).
 
     Global Instance DTM_TM (dtm : DTM) : TM :=
     {|
         init := d_init dtm;
         final := d_final dtm;
 
-        transitions := DTransitions work_tapes_num;
-        do_transition := id; (*TODO*)
+        exist_transition := exist_d_transition (d_transitions dtm);
     |}.
+
+    Definition NTransitions := Q * TransitionCond -> list (Q * TransitionAction).
 
     Record NTM := {
         n_init : Q;
         n_final : Q -> bool;
+
+        n_transitions : NTransitions;
     }.
 
-    Definition NTransitions (n : nat) :=
-        Q * Σ * (Vector.t Γ n) -> 
-        list (Q * (Vector.t Γ n) * Move * (Vector.t Move n)).
+    Definition exist_n_transition (n_transitions : NTransitions) (p : P) (c1 c2 : Conf) := 
+        let (cond, action) := p in
+        let possible_transitions := n_transitions (state c1, cond) in
+        
+        (get_input_symbol c1 = Some (input_symbol cond)) /\
+        (exists (expected_state : Q) (expected_action : TransitionAction),
+            List.In (expected_state, expected_action) possible_transitions /\
+            expected_action = action /\
+            expected_state = state c2) /\
+        (input c2 = input c1) /\
+        (input_index c2 = update_index (input_index c1) (input_move action)) /\
+        (work_tapes_consistent c1 c2 cond action).
 
     Global Instance NTM_TM (ntm : NTM) : TM :=
     {|
         init := n_init ntm;
         final := n_final ntm;
 
-        transitions := NTransitions work_tapes_num;
-        do_transition := id; (*TODO*)
+        exist_transition := exist_n_transition (n_transitions ntm);
     |}.
 
     Inductive QType := Existential | Universal.
@@ -75,6 +153,7 @@ Section TuringMachines.
         a_final : Q -> bool;
 
         q_type : Q -> QType;
+        a_transitions : NTransitions;
     }.
 
     Global Instance ATM_TM (atm : ATM) : TM :=
@@ -82,20 +161,34 @@ Section TuringMachines.
         init := a_init atm;
         final := a_final atm;
 
-        transitions := NTransitions work_tapes_num;
-        do_transition := id; (*TODO*)
+        exist_transition := exist_n_transition (a_transitions atm);
     |}.
 End TuringMachines.
 
-Definition transition `{TMParams} (tm : TM) (conf1 conf2 : Conf) : Prop :=
-    do_transition conf1 = conf2.
+Definition transition `{TMParams} (tm : TM) (p : P) (conf1 conf2 : Conf) : Prop :=
+    exist_transition p conf1 conf2.
 
-Notation "conf1 ⊢ᶜ conf2" := (transition _ conf1 conf2) (at level 70).
+Notation "conf1 ○ p ⊢ᶜ conf2" := (transition _ p conf1 conf2) (at level 70).
 
-Definition ttransition `{TMParams} (tm : TM) (trace1 trace2 : Trace) : Prop :=
-    let head1 := head trace1 in
-    let head2 := head trace2 in
-        trace2 = cons head2 (trace1) /\
-        head1 ⊢ᶜ head2.
+Definition Trace `{TM} := 
+    { t : NEList Conf |
+        let confs := toList t in
+        (fix check_confs (cs : list Conf) (prev : option Conf) : Prop :=
+            match cs, prev with
+            | [], _ => True
+            | c :: rest, None => check_confs rest (Some c)
+            | c :: rest, Some prev_c =>
+                exists (p : P), prev_c ○ p ⊢ᶜ c /\
+                check_confs rest (Some c)
+            end) confs None }.
 
-Notation "trace1 ⊢ trace2" := (ttransition _ trace1 trace2) (at level 70).
+Definition ttransition `{TMParams} (tm : TM) (p : P) (trace1 trace2 : Trace) : Prop :=
+    match trace1, trace2 with
+    | exist _ t1 _, exist _ t2 _ =>
+        let head1 := head t1 in
+        let head2 := head t2 in
+            t2 = cons head2 (t1) /\
+            head1 ○ p ⊢ᶜ head2
+    end.
+
+Notation "trace1 ○ p ⊢ trace2" := (ttransition _ p trace1 trace2) (at level 70).

--- a/src/TM.v
+++ b/src/TM.v
@@ -1,50 +1,101 @@
-From Coq Require Fin.
+Set Warnings "-stdlib-vector".
+From Coq Require Vectors.Vector.
 From klenee_complexity Require Import NEList.
 
-Class TMParams := {
-  Q : Type;
-  Σ : Type;
-  Γ : Type;
-  work_tapes_num : nat;
-}.
-
 Section TuringMachines.
-    Context `{TMParams}.
-
-    Inductive Move := Left | Right | Stay. 
-
-    Record TM (TransitionsFunc : nat -> Type) := {
-        init : Q;
-        final : Q -> bool;
-        transitions : TransitionsFunc work_tapes_num;
+    Class TMParams := {
+        Q : Type;
+        Σ : Type;
+        Γ : Type;
+        work_tapes_num : nat;
     }.
 
-    Definition DTransitions (n : nat) :=
-        Q * Σ * (Fin.t n -> Γ) -> 
-        Q * (Fin.t n -> Γ) * Move * (Fin.t n -> Move).
-
-    Definition NTransitions (n : nat) :=
-        Q * Σ * (Fin.t n -> Γ) -> 
-        list (Q * (Fin.t n -> Γ) * Move * (Fin.t n -> Move)).
-
-    Definition DTM := TM DTransitions.
-    Definition NTM := TM NTransitions.
-
-    Inductive QType := Existential | Universal.
-
-    Record ATM := {
-        ntm : NTM;
-        q_type : Q -> QType;
-    }.
+    Context `{params : TMParams}.
 
     Record Conf := {
         state : Q;
         input : list Σ;
         input_index : nat;
-        work_tapes : Fin.t work_tapes_num -> list Γ;
-        work_tapes_indices : Fin.t work_tapes_num -> nat;
+        work_tapes : Vector.t (list Γ) work_tapes_num;
+        work_tapes_indices : Vector.t nat work_tapes_num;
     }.
 
-    Definition Trace := NEList Conf.
+    Definition Trace  := NEList Conf.
 
+    Class TM := {
+        init : Q;
+        final : Q -> bool;
+
+        transitions : Type;
+        do_transition : Conf -> Conf;
+    }.
+
+    Record DTM := {
+        d_init : Q;
+        d_final : Q -> bool;
+    }.
+
+    Inductive Move := Left | Right | Stay. 
+
+    Definition DTransitions (n : nat) :=
+        Q * Σ * (Vector.t Γ n) -> 
+        Q * (Vector.t Γ n) * Move * (Vector.t Move n).
+
+    Global Instance DTM_TM (dtm : DTM) : TM :=
+    {|
+        init := d_init dtm;
+        final := d_final dtm;
+
+        transitions := DTransitions work_tapes_num;
+        do_transition := id; (*TODO*)
+    |}.
+
+    Record NTM := {
+        n_init : Q;
+        n_final : Q -> bool;
+    }.
+
+    Definition NTransitions (n : nat) :=
+        Q * Σ * (Vector.t Γ n) -> 
+        list (Q * (Vector.t Γ n) * Move * (Vector.t Move n)).
+
+    Global Instance NTM_TM (ntm : NTM) : TM :=
+    {|
+        init := n_init ntm;
+        final := n_final ntm;
+
+        transitions := NTransitions work_tapes_num;
+        do_transition := id; (*TODO*)
+    |}.
+
+    Inductive QType := Existential | Universal.
+
+    Record ATM := {
+        a_init : Q;
+        a_final : Q -> bool;
+
+        q_type : Q -> QType;
+    }.
+
+    Global Instance ATM_TM (atm : ATM) : TM :=
+    {|
+        init := a_init atm;
+        final := a_final atm;
+
+        transitions := NTransitions work_tapes_num;
+        do_transition := id; (*TODO*)
+    |}.
 End TuringMachines.
+
+Definition transition `{TMParams} (tm : TM) (conf1 conf2 : Conf) : Prop :=
+    do_transition conf1 = conf2.
+
+Notation "conf1 ⊢ᶜ conf2" := (transition _ conf1 conf2) (at level 70).
+
+Definition ttransition `{TMParams} (tm : TM) (trace1 trace2 : Trace) : Prop :=
+    let head1 := head trace1 in
+    let head2 := head trace2 in
+        trace2 = cons head2 (trace1) /\
+        head1 ⊢ᶜ head2.
+
+Notation "trace1 ⊢ trace2" := (ttransition _ trace1 trace2) (at level 70).

--- a/src/TM.v
+++ b/src/TM.v
@@ -1,0 +1,50 @@
+From Coq Require Fin.
+From klenee_complexity Require Import NEList.
+
+Class TMParams := {
+  Q : Type;
+  Σ : Type;
+  Γ : Type;
+  work_tapes_num : nat;
+}.
+
+Section TuringMachines.
+    Context `{TMParams}.
+
+    Inductive Move := Left | Right | Stay. 
+
+    Record TM (TransitionsFunc : nat -> Type) := {
+        init : Q;
+        final : Q -> bool;
+        transitions : TransitionsFunc work_tapes_num;
+    }.
+
+    Definition DTransitions (n : nat) :=
+        Q * Σ * (Fin.t n -> Γ) -> 
+        Q * (Fin.t n -> Γ) * Move * (Fin.t n -> Move).
+
+    Definition NTransitions (n : nat) :=
+        Q * Σ * (Fin.t n -> Γ) -> 
+        list (Q * (Fin.t n -> Γ) * Move * (Fin.t n -> Move)).
+
+    Definition DTM := TM DTransitions.
+    Definition NTM := TM NTransitions.
+
+    Inductive QType := Existential | Universal.
+
+    Record ATM := {
+        ntm : NTM;
+        q_type : Q -> QType;
+    }.
+
+    Record Conf := {
+        state : Q;
+        input : list Σ;
+        input_index : nat;
+        work_tapes : Fin.t work_tapes_num -> list Γ;
+        work_tapes_indices : Fin.t work_tapes_num -> nat;
+    }.
+
+    Definition Trace := NEList Conf.
+
+End TuringMachines.


### PR DESCRIPTION
В файле TM реализовал машины тьюринга (DTM, NTM, ATM), их переходы и конфигурации. 

Эндофункторы pre и post с использованием нотаций выглядят так (их и алгебру из них занесу в отдельной ветке):

```
    Definition post : Endo := 
        fun d => fun i => fun t' => exists t p, In _ (d i) t /\ t ○ p ⊢ t'.

    Definition pre : Endo := 
        fun d => fun i => fun t => exists t' p, In _ (d i) t' /\ t ○ p ⊢ t'.
``` 